### PR TITLE
Update Mixins

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1641429628
+//version: 1642394973
 /*
 DO NOT CHANGE THIS FILE!
 
@@ -223,7 +223,7 @@ dependencies {
         annotationProcessor("com.google.code.gson:gson:2.8.6")
         annotationProcessor("org.spongepowered:mixin:0.8-SNAPSHOT")
         // using 0.8 to workaround a issue in 0.7 which fails mixin application
-        compile("org.spongepowered:mixin:0.7.11-SNAPSHOT") {
+        compile("com.github.GTNewHorizons:SpongePoweredMixin:0.7.12-GTNH") {
             // Mixin includes a lot of dependencies that are too up-to-date
             exclude module: "launchwrapper"
             exclude module: "guava"
@@ -231,7 +231,7 @@ dependencies {
             exclude module: "commons-io"
             exclude module: "log4j-core"
         }
-        compile("com.github.GTNewHorizons:SpongeMixins:1.3.3:dev")
+        compile("com.github.GTNewHorizons:SpongeMixins:1.5.0")
     }
 }
 


### PR DESCRIPTION
 Switch to SpongeMixins 1.5.0 (Non dev version until shading is figured out for dev jar), and GTNH fork of SpongePowered Mixin (Allows running dependencies that use mixins, in dev)