### PR TITLE
Add methods to deobfuscate dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ src/main/resources/mixins.*.json
 *.bat
 *.DS_Store
 !gradlew.bat
+/data/
+/deobfDependencies/

--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,4 @@ src/main/resources/mixins.*.json
 *.bat
 *.DS_Store
 !gradlew.bat
-/data/
-/deobfDependencies/
+/deobf/

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1642800000
+//version: 1642844806
 /*
 DO NOT CHANGE THIS FILE!
 
@@ -595,7 +595,7 @@ def deobf(String sourceURL, String fileName) {
     }
 
     download {
-        src 'https://github.com/glowredman/BON2/releases/download/2.5.0/BON2-2.5.0.CUSTOM-all.jar'
+        src 'https://github.com/GTNewHorizons/BON2/releases/download/2.5.0/BON2-2.5.0.CUSTOM-all.jar'
         dest bon2File
         quiet true
         overwrite false

--- a/build.gradle
+++ b/build.gradle
@@ -586,13 +586,9 @@ configure(updateBuildScript) {
 // Deobfuscation
 
 def deobf(String sourceURL, String fileName) {
-    return deobf(sourceURL, fileName, false)
-}
-
-def deobf(String sourceURL, String fileName, boolean notch) {
-    def bon2File  = "$projectDir/data/BON2-2.5.0.jar"
-    def cacheFile = "$projectDir/deobfDependencies/" + fileName + ".jar"
-    def deobfFile = "$projectDir/deobfDependencies/" + fileName + "-deobf.jar"
+    def bon2File  = "$projectDir/deobf/BON2-2.5.0.jar"
+    def cacheFile = "$projectDir/deobf/out/" + fileName + ".jar"
+    def deobfFile = "$projectDir/deobf/out/" + fileName + "-deobf.jar"
 
     if(file(deobfFile).exists()) {
         return files(deobfFile)
@@ -612,15 +608,12 @@ def deobf(String sourceURL, String fileName, boolean notch) {
         overwrite false
     }
 
-    if(notch) {
-        exec {
-            commandLine 'java', '-jar', bon2File, '--inputJar', cacheFile, '--outputJar', deobfFile, '--mcVer', '1.7.10', '--mappingsVer', 'stable_12'
-        }
-    } else {
-        exec {
-            commandLine 'java', '-jar', bon2File, '--inputJar', cacheFile, '--outputJar', deobfFile, '--mcVer', '1.7.10', '--mappingsVer', 'stable_12', '--notch'
-        }
+    exec {
+        commandLine 'java', '-jar', bon2File, '--inputJar', cacheFile, '--outputJar', deobfFile, '--mcVer', '1.7.10', '--mappingsVer', 'stable_12', '--notch'
+        workingDir "$projectDir/deobf"
+        standardOutput = new ByteArrayOutputStream()
     }
+
     delete(cacheFile)
     return files(deobfFile)
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1642484596
+//version: 1642800000
 /*
 DO NOT CHANGE THIS FILE!
 
@@ -43,6 +43,7 @@ plugins {
     id("org.ajoberstar.grgit") version("3.1.1")
     id("com.github.johnrengelman.shadow") version("4.0.4")
     id("com.palantir.git-version") version("0.12.3")
+    id('de.undercouch.download') version('4.1.2')
     id("maven-publish")
 }
 
@@ -580,6 +581,48 @@ static String getVersionHash(String buildScriptContent) {
 configure(updateBuildScript) {
     group = 'forgegradle'
     description = 'Updates the build script to the latest version'
+}
+
+// Deobfuscation
+
+def deobf(String sourceURL, String fileName) {
+    return deobf(sourceURL, fileName, false)
+}
+
+def deobf(String sourceURL, String fileName, boolean notch) {
+    def bon2File  = "$projectDir/data/BON2-2.5.0.jar"
+    def cacheFile = "$projectDir/deobfDependencies/" + fileName + ".jar"
+    def deobfFile = "$projectDir/deobfDependencies/" + fileName + "-deobf.jar"
+
+    if(file(deobfFile).exists()) {
+        return files(deobfFile)
+    }
+
+    download {
+        src 'https://github.com/glowredman/BON2/releases/download/2.5.0/BON2-2.5.0.CUSTOM-all.jar'
+        dest bon2File
+        quiet true
+        overwrite false
+    }
+
+    download {
+        src sourceURL
+        dest cacheFile
+        quiet true
+        overwrite false
+    }
+
+    if(notch) {
+        exec {
+            commandLine 'java', '-jar', bon2File, '--inputJar', cacheFile, '--outputJar', deobfFile, '--mcVer', '1.7.10', '--mappingsVer', 'stable_12'
+        }
+    } else {
+        exec {
+            commandLine 'java', '-jar', bon2File, '--inputJar', cacheFile, '--outputJar', deobfFile, '--mcVer', '1.7.10', '--mappingsVer', 'stable_12', '--notch'
+        }
+    }
+    delete(cacheFile)
+    return files(deobfFile)
 }
 
 // Helper methods


### PR DESCRIPTION
**Usage:**
`compile deobf(sourceURL, fileName, notch)`

- fileName has to be *without* .jar
- supports both SRG and NOTCH mappings. Mods are usually compiled with SRG mappings but some mods (e.g. VoxelMap) are compiled with NOTCH mappings
- deobfuscated jars are placed in `/deobf/out/`
- the BON2 jar and all deobf jars are cached

**Example:**
BuildCraftCompat dependencies:
```groovy
dependencies {
    // other deps
    compileOnly deobf("https://www.immibis.com/mcmoddl/files/redlogic-59.1.13.jar", "redlogic-59.1.13")
    compileOnly deobf("https://www.immibis.com/mcmoddl/files/immibis-microblocks-59.1.2.jar", "immibis-microblocks-59.1.2")
    compileOnly deobf("https://www.immibis.com/mcmoddl/files/immibis-core-59.1.4.jar", "immibis-core-59.1.4")
}
```
VisualProspecting:
```groovy
dependencies {
    // other deps
    compileOnly deobf("https://media.forgecdn.net/files/2462/146/mod_voxelMap_1.7.0b_for_1.7.10.litemod", "voxelmap_1.7.0b")
}
```
As you can see, this also works for CurseForge mods, you just need to get the direct link.


I'm not a gradle wizard so I hapilly take feedback :)