### PR TITLE
Remove non GTNH deps from the generated pom.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1642784244
+//version: 1642833682
 /*
 DO NOT CHANGE THIS FILE!
 
@@ -515,6 +515,18 @@ publishing {
             artifactId = System.getenv("ARTIFACT_ID") ?: project.name
             // Using the identified version, not project.version as it has the prepended 1.7.10
             version = System.getenv("RELEASE_VERSION") ?: identifiedVersion
+            
+            // Remove all non GTNH deps here.
+            // Original intention was to remove an invalid forgeBin being generated without a groupId (mandatory), but
+            // it also removes all of the MC deps
+            pom.withXml {
+                Node pomNode = asNode()
+                pomNode.dependencies.'*'.findAll() {
+                    it.groupId.text() != 'com.github.GTNewHorizons'
+                }.each() {
+                    it.parent().remove(it)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Cleans up a lot of noisy deps anyway.

Fixes:
```
Execution failed for task ':compileJava'.
> Could not resolve all files for configuration ':compileClasspath'.
   > Could not resolve com.github.GTNewHorizons:NotEnoughItems:2.2.0-GTNH.
     Required by:
         project :
      > Could not resolve com.github.GTNewHorizons:NotEnoughItems:2.2.0-GTNH.
         > Could not parse POM http://jenkins.usrv.eu:8081/nexus/content/groups/public/com/github/GTNewHorizons/NotEnoughItems/2.2.0-GTNH/NotEnoughItems-2.2.0-GTNH.pom
            > Missing required attribute: dependency groupId
```

ForgeBin was being generated without a groupId
```xml
<dependency>
<artifactId>forgeBin</artifactId>
<version>1.7.10-10.13.4.1614-1.7.10</version>
<scope>compile</scope>
</dependency>
```