### PR TITLE
Maybe finally fix generating dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1642844806
+//version: 1642872913
 /*
 DO NOT CHANGE THIS FILE!
 
@@ -496,11 +496,21 @@ artifacts {
     }
 }
 
+// The gradle metadata includes all of the additional deps that we disabled from POM generation (including forgeBin with no groupID), 
+// and isn't strictly needed with the POM so just disable it.
+tasks.withType(GenerateModuleMetadata) {
+    enabled = false
+}
+
+
 // publishing
 publishing {
     publications {
         maven(MavenPublication) {
-            artifact source: usesShadowedDependencies.toBoolean() ? shadowJar : jar, classifier: ""
+            from components.java
+            if(usesShadowedDependencies.toBoolean()) {
+                artifact source: shadowJar, classifier: ""
+            }
             if(!noPublishedSources) {
                 artifact source: sourcesJar, classifier: "src"
             }
@@ -513,6 +523,18 @@ publishing {
             artifactId = System.getenv("ARTIFACT_ID") ?: project.name
             // Using the identified version, not project.version as it has the prepended 1.7.10
             version = System.getenv("RELEASE_VERSION") ?: identifiedVersion
+            
+            // Remove all non GTNH deps here.
+            // Original intention was to remove an invalid forgeBin being generated without a groupId (mandatory), but
+            // it also removes all of the MC deps
+            pom.withXml {
+                Node pomNode = asNode()
+                pomNode.dependencies.'*'.findAll() {
+                    it.groupId.text() != 'com.github.GTNewHorizons'
+                }.each() {
+                    it.parent().remove(it)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Revert "Revert "This seems to generate dependencies in the POM file.""
This reverts commit ba14c444c3f6741c7d9f96315a2bb20786858840.

Revert "Revert "Remove non GTNH deps from the generated pom.  Cleans up a lot of noisy deps anyway.""
This reverts commit 286a547090f8328d2fac0e0b576813c7fbe6cb13.

Don't generate gradle metadata