### PR TITLE
Update deobf method to save BON2 and deobfuscated jars in the gradle directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,3 @@ src/main/resources/mixins.*.json
 *.bat
 *.DS_Store
 !gradlew.bat
-/deobf/

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1642964305
+//version: 1643020202
 /*
 DO NOT CHANGE THIS FILE!
 
@@ -598,11 +598,43 @@ configure(updateBuildScript) {
 
 // Deobfuscation
 
-def deobf(String sourceURL, String fileName) {
-    def bon2File  = "$projectDir/deobf/BON2-2.5.0.jar"
-    def cacheFile = "$projectDir/deobf/out/" + fileName + ".jar"
-    def deobfFile = "$projectDir/deobf/out/" + fileName + "-deobf.jar"
+def deobf(String sourceURL) {
+    try {
+        URL url = new URL(sourceURL)
+        String fileName = url.getFile()
 
+        //get rid of directories:
+        int lastSlash = fileName.lastIndexOf("/")
+        if(lastSlash > 0) {
+            fileName = fileName.substring(lastSlash + 1)
+        }
+        //get rid of extension:
+        if(fileName.endsWith(".jar")) {
+            fileName = fileName.substring(0, fileName.lastIndexOf("."))
+        }
+
+        String hostName = url.getHost()
+        if(hostName.startsWith("www.")) {
+            hostName = hostName.substring(4)
+        }
+        List parts = Arrays.asList(hostName.split("\\."))
+        Collections.reverse(parts)
+        hostName = String.join(".", parts)
+
+        return deobf(sourceURL, hostName + "/" + fileName)
+    } catch(Exception e) {
+        return deobf(sourceURL, "deobf/" + String.valueOf(sourceURL.hashCode()))
+    }
+}
+
+// The method above is to be prefered. Use this method if the filename is not at the end of the URL.
+def deobf(String sourceURL, String fileName) {
+    String cacheDir = System.getProperty("user.home") + "/.gradle/caches/"
+    String bon2Dir = cacheDir + "forge_gradle/deobf"
+    String bon2File  = bon2Dir + "/BON2-2.5.0.jar"
+    String obfFile = cacheDir + "modules-2/files-2.1/" + fileName + ".jar"
+    String deobfFile = cacheDir + "modules-2/files-2.1/" + fileName + "-deobf.jar"
+    
     if(file(deobfFile).exists()) {
         return files(deobfFile)
     }
@@ -616,18 +648,17 @@ def deobf(String sourceURL, String fileName) {
 
     download {
         src sourceURL
-        dest cacheFile
+        dest obfFile
         quiet true
         overwrite false
     }
 
     exec {
-        commandLine 'java', '-jar', bon2File, '--inputJar', cacheFile, '--outputJar', deobfFile, '--mcVer', '1.7.10', '--mappingsVer', 'stable_12', '--notch'
-        workingDir "$projectDir/deobf"
+        commandLine 'java', '-jar', bon2File, '--inputJar', obfFile, '--outputJar', deobfFile, '--mcVer', '1.7.10', '--mappingsVer', 'stable_12', '--notch'
+        workingDir bon2Dir
         standardOutput = new ByteArrayOutputStream()
     }
 
-    delete(cacheFile)
     return files(deobfFile)
 }
 


### PR DESCRIPTION
- The BON2 jar will be saved in `$USER_HOME/.gradle/caches/forge_gradle/deobf`, the `data`-directory BON2 creates will be saved there too.
- Raw and deobfuscated jars will be saved to `$USER_HOME/.gradle/caches/modules-2/files-2.1/`.
- There now is an addtional method which takes only the sourceURL as argument and tries to extract the host- and filename from it. ***This method should be prioritized***. *Examples:* `https://www.immibis.com/mcmoddl/files/immibis-core-59.1.4.jar` results in `/com.immibis/immibis-core-59.1.4.jar` and `/com.immibis/immibis-core-59.1.4-deobf.jar`; `https://media.forgecdn.net/files/2261/766/AuraCascade-557.jar` results in `/net.forgecdn.media/AuraCascade-557.jar` and `/net.forgecdn.media/AuraCascade-557-deobf.jar`.

The goal is to not store BON2 and the deobfuscated jars for each project but rather in a central place. This reduces both internet bandwidth and required disk-space. Having to specify the filename in the deobf method requires all devs to use the same names, so I chose to generate filename and path depending on the URL provided. If the algorithm fails (e.g. because a Dropbox link is used), the file will be placed in the `/files-2.1/deobf`-directory and the hashed sourceURL is used as filename. Because this makes the file unidentifiable, the second method can still be used.