### PR TITLE
Warn if git is not present, actually set VERSION override if used

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Example Forge Mod for Minecraft 1.7.10
 
-[![](https://jitpack.io/v/SinTh0r4s/ExampleMod1.7.10.svg)](https://jitpack.io/#SinTh0r4s/ExampleMod1.7.10)
-[![](https://github.com/SinTh0r4s/ExampleMod1.7.10/actions/workflows/gradle.yml/badge.svg)](https://github.com/SinTh0r4s/ExampleMod1.7.10/actions/workflows/gradle.yml)
+[![](https://jitpack.io/v/GTNewHorizons/ExampleMod1.7.10.svg)](https://jitpack.io/#GTNewHorizons/ExampleMod1.7.10)
+[![](https://github.com/GTNewHorizons/ExampleMod1.7.10/actions/workflows/gradle.yml/badge.svg)](https://github.com/GTNewHorizons/ExampleMod1.7.10/actions/workflows/gradle.yml)
 
 An example mod for Minecraft 1.7.10 with Forge focussed on a stable, updatable setup.
 
@@ -11,12 +11,12 @@ We had our fair share in struggles with build scripts for Minecraft Forge. There
 
 ### Help! I'm stuck!
 
-We all have been there! Check out our [FAQ](https://github.com/SinTh0r4s/ExampleMod1.7.10/blob/main/docs/FAQ.md). If that doesn't help, please open an issue.
+We all have been there! Check out our [FAQ](https://github.com/GTNewHorizons/ExampleMod1.7.10/blob/main/docs/FAQ.md). If that doesn't help, please open an issue.
 
 ### Getting started
 
 Creating mod from scratch:
-1. Unzip [project starter](https://github.com/SinTh0r4s/ExampleMod1.7.10/releases/download/latest-packages/starter.zip) into project directory.
+1. Unzip [project starter](https://github.com/GTNewHorizons/ExampleMod1.7.10/releases/download/latest-packages/starter.zip) into project directory.
 2. Replace placeholders in LICENSE-template and rename it to LICENSE, or remove LICENSE-template and put any other license you like on your code. This is an permissive OSS project and we encourage you participate in OSS movement by having permissive license like one in template. You can find out pros and cons of OSS software in [this article](https://www.freecodecamp.org/news/what-is-great-about-developing-open-source-and-what-is-not/)
 3. Ensure your project is under VCS. For example initialise git repository by running `git init; git commit --message "initialized repository"`.
 4. Replace placeholders (edit values in gradle.properties, change example package and class names, etc.)
@@ -28,7 +28,7 @@ We also have described guidelines for existing mod [migration](docs/migration.md
 
 ### Features
 
- - Updatable: Replace [`build.gradle`](https://github.com/SinTh0r4s/ExampleMod1.7.10/blob/main/build.gradle) with a newer version
+ - Updatable: Replace [`build.gradle`](https://github.com/GTNewHorizons/ExampleMod1.7.10/blob/main/build.gradle) with a newer version
  - Optional API artifact (.jar)
  - Optional version replacement in Java files
  - Optional shadowing of dependencies
@@ -44,12 +44,12 @@ We also have described guidelines for existing mod [migration](docs/migration.md
    - Running smoke test for server startup. On any server crash occurring workflow will fail and print the crash log.
 
 ### Files
- - [`build.gradle`](https://github.com/SinTh0r4s/ExampleMod1.7.10/blob/main/build.gradle): This is the core script of the build process. You should not need to tamper with it, unless you are trying to accomplish something out of the ordinary. __Do not touch this file! You will make a future update near impossible if you do so!__
- - [`gradle.properties`](https://github.com/SinTh0r4s/ExampleMod1.7.10/blob/main/gradle.properties): The core configuration file. It includes 
- - [`dependencies.gradle`](https://github.com/SinTh0r4s/ExampleMod1.7.10/blob/main/dependencies.gradle): Add your mod's dependencies in this file. This is separate from the main build script, so you may replace the [`build.gradle`](https://github.com/SinTh0r4s/ExampleMod1.7.10/blob/main/build.gradle) if an update is available.
- - [`repositories.gradle`](https://github.com/SinTh0r4s/ExampleMod1.7.10/blob/main/repositories.gradle): Add your dependencies' repositories. This is separate from the main build script, so you may replace the [`build.gradle`](https://github.com/SinTh0r4s/ExampleMod1.7.10/blob/main/build.gradle) if an update is available.
- - [`jitpack.yml`](https://github.com/SinTh0r4s/ExampleMod1.7.10/blob/main/jitpack.yml): Ensures that your mod is available as import over [Jitpack](https://jitpack.io).
- - [`.github/workflows/gradle.yml`](https://github.com/SinTh0r4s/ExampleMod1.7.10/blob/main/.github/workflows/gradle.yml): A simple CI script that will build your mod any time it is pushed to `master` or `main` and publish the result as release in your repository. This feature is free with GitHub if your repository is public.
+ - [`build.gradle`](https://github.com/GTNewHorizons/ExampleMod1.7.10/blob/main/build.gradle): This is the core script of the build process. You should not need to tamper with it, unless you are trying to accomplish something out of the ordinary. __Do not touch this file! You will make a future update near impossible if you do so!__
+ - [`gradle.properties`](https://github.com/GTNewHorizons/ExampleMod1.7.10/blob/main/gradle.properties): The core configuration file. It includes 
+ - [`dependencies.gradle`](https://github.com/GTNewHorizons/ExampleMod1.7.10/blob/main/dependencies.gradle): Add your mod's dependencies in this file. This is separate from the main build script, so you may replace the [`build.gradle`](https://github.com/SinTh0r4s/ExampleMod1.7.10/blob/main/build.gradle) if an update is available.
+ - [`repositories.gradle`](https://github.com/GTNewHorizons/ExampleMod1.7.10/blob/main/repositories.gradle): Add your dependencies' repositories. This is separate from the main build script, so you may replace the [`build.gradle`](https://github.com/SinTh0r4s/ExampleMod1.7.10/blob/main/build.gradle) if an update is available.
+ - [`jitpack.yml`](https://github.com/GTNewHorizons/ExampleMod1.7.10/blob/main/jitpack.yml): Ensures that your mod is available as import over [Jitpack](https://jitpack.io).
+ - [`.github/workflows/gradle.yml`](https://github.com/GTNewHorizons/ExampleMod1.7.10/blob/main/.github/workflows/gradle.yml): A simple CI script that will build your mod any time it is pushed to `master` or `main` and publish the result as release in your repository. This feature is free with GitHub if your repository is public.
 
 ### Forge's Access Transformers
 

--- a/build.gradle
+++ b/build.gradle
@@ -185,7 +185,7 @@ catch (Exception e) {
     identifiedVersion = versionOverride
 }
 version = minecraftVersion + '-' + identifiedVersion
-String modVersion = version
+String modVersion = identifiedVersion
 
 if( identifiedVersion.equals(versionOverride) ) {
     logger.error('\u001B[31m\u001B[7mWe hope you know what you\'re doing using\u001B[0m\u001B[1;34m ' + modVersion + '\u001B[0m\n');

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1643844119
+//version: 1644194279
 /*
 DO NOT CHANGE THIS FILE!
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1644194279
+//version: 1644278435
 /*
 DO NOT CHANGE THIS FILE!
 
@@ -685,14 +685,14 @@ def deobf(String sourceURL, String fileName) {
         return files(deobfFile)
     }
 
-    download {
+    download.run {
         src 'https://github.com/GTNewHorizons/BON2/releases/download/2.5.0/BON2-2.5.0.CUSTOM-all.jar'
         dest bon2File
         quiet true
         overwrite false
     }
 
-    download {
+    download.run {
         src sourceURL
         dest obfFile
         quiet true

--- a/build.gradle
+++ b/build.gradle
@@ -673,7 +673,7 @@ def deobf(String sourceURL) {
     }
 }
 
-// The method above is to be prefered. Use this method if the filename is not at the end of the URL.
+// The method above is to be preferred. Use this method if the filename is not at the end of the URL.
 def deobf(String sourceURL, String fileName) {
     String cacheDir = System.getProperty("user.home") + "/.gradle/caches/"
     String bon2Dir = cacheDir + "forge_gradle/deobf"

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ plugins {
     id 'idea'
     id 'eclipse'
     id 'scala'
-    id('org.jetbrains.kotlin.jvm') version ('1.6.10') apply false
+    id('org.jetbrains.kotlin.jvm') version ('1.6.10')
     id('org.ajoberstar.grgit') version('4.1.1')
     id('com.github.johnrengelman.shadow') version('4.0.4')
     id('com.palantir.git-version') version('0.13.0') apply false
@@ -53,6 +53,12 @@ if (project.file('.git/HEAD').isFile()) {
 }
 
 apply plugin: 'forge'
+
+compileKotlin {
+    kotlinOptions {
+        jvmTarget = 1.8
+    }
+}
 
 def projectJavaVersion = JavaLanguageVersion.of(8)
 
@@ -99,24 +105,27 @@ boolean noPublishedSources = project.findProperty("noPublishedSources") ? projec
 
 String javaSourceDir = "src/main/java/"
 String scalaSourceDir = "src/main/scala/"
+String kotlinSourceDir = "src/main/kotlin/"
 
 String targetPackageJava = javaSourceDir + modGroup.toString().replaceAll("\\.", "/")
 String targetPackageScala = scalaSourceDir + modGroup.toString().replaceAll("\\.", "/")
-if((getFile(targetPackageJava).exists() || getFile(targetPackageScala).exists()) == false) {
-    throw new GradleException("Could not resolve \"modGroup\"! Could not find " + targetPackageJava + " or " + targetPackageScala)
+String targetPackageKotlin = kotlinSourceDir + modGroup.toString().replaceAll("\\.", "/")
+if(!(getFile(targetPackageJava).exists() || getFile(targetPackageScala).exists() || getFile(targetPackageKotlin).exists())) {
+    throw new GradleException("Could not resolve \"modGroup\"! Could not find " + targetPackageJava + " or " + targetPackageScala + " or " + targetPackageKotlin)
 }
 
 if(apiPackage) {
     targetPackageJava = javaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + apiPackage.toString().replaceAll("\\.", "/")
     targetPackageScala = scalaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + apiPackage.toString().replaceAll("\\.", "/")
-    if((getFile(targetPackageJava).exists() || getFile(targetPackageScala).exists()) == false) {
-        throw new GradleException("Could not resolve \"apiPackage\"! Could not find " + targetPackageJava + " or " + targetPackageScala)
+    targetPackageKotlin = kotlinSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + apiPackage.toString().replaceAll("\\.", "/")
+    if(!(getFile(targetPackageJava).exists() || getFile(targetPackageScala).exists() || getFile(targetPackageKotlin).exists())) {
+        throw new GradleException("Could not resolve \"apiPackage\"! Could not find " + targetPackageJava + " or " + targetPackageScala + " or " + targetPackageKotlin)
     }
 }
 
 if(accessTransformersFile) {
     String targetFile = "src/main/resources/META-INF/" + accessTransformersFile
-    if(getFile(targetFile).exists() == false) {
+    if(!getFile(targetFile).exists()) {
         throw new GradleException("Could not resolve \"accessTransformersFile\"! Could not find " + targetFile)
     }
 }
@@ -128,15 +137,17 @@ if(usesMixins.toBoolean()) {
 
     targetPackageJava = javaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + mixinsPackage.toString().replaceAll("\\.", "/")
     targetPackageScala = scalaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + mixinsPackage.toString().replaceAll("\\.", "/")
-    if((getFile(targetPackageJava).exists() || getFile(targetPackageScala).exists()) == false) {
-        throw new GradleException("Could not resolve \"mixinsPackage\"! Could not find " + targetPackageJava + " or " + targetPackageScala)
+    targetPackageKotlin = kotlinSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + mixinsPackage.toString().replaceAll("\\.", "/")
+    if(!(getFile(targetPackageJava).exists() || getFile(targetPackageScala).exists() || getFile(targetPackageKotlin).exists())) {
+        throw new GradleException("Could not resolve \"mixinsPackage\"! Could not find " + targetPackageJava + " or " + targetPackageScala  + " or " + targetPackageKotlin)
     }
 
     String targetFileJava = javaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + mixinPlugin.toString().replaceAll("\\.", "/") + ".java"
     String targetFileScala = scalaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + mixinPlugin.toString().replaceAll("\\.", "/") + ".scala"
     String targetFileScalaJava = scalaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + mixinPlugin.toString().replaceAll("\\.", "/") + ".java"
-    if((getFile(targetFileJava).exists() || getFile(targetFileScala).exists() || getFile(targetFileScalaJava).exists()) == false) {
-        throw new GradleException("Could not resolve \"mixinPlugin\"! Could not find " + targetFileJava + " or " + targetFileScala + " or " + targetFileScalaJava)
+    String targetFileKotlin = kotlinSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + mixinPlugin.toString().replaceAll("\\.", "/") + ".kt"
+    if(!(getFile(targetFileJava).exists() || getFile(targetFileScala).exists() || getFile(targetFileScalaJava).exists() || getFile(targetFileKotlin).exists())) {
+        throw new GradleException("Could not resolve \"mixinPlugin\"! Could not find " + targetFileJava + " or " + targetFileScala + " or " + targetFileScalaJava + " or " + targetFileKotlin)
     }
 }
 
@@ -144,8 +155,9 @@ if(coreModClass) {
     String targetFileJava = javaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + coreModClass.toString().replaceAll("\\.", "/") + ".java"
     String targetFileScala = scalaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + coreModClass.toString().replaceAll("\\.", "/") + ".scala"
     String targetFileScalaJava = scalaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + coreModClass.toString().replaceAll("\\.", "/") + ".java"
-    if((getFile(targetFileJava).exists() || getFile(targetFileScala).exists() || getFile(targetFileScalaJava).exists()) == false) {
-        throw new GradleException("Could not resolve \"coreModClass\"! Could not find " + targetFileJava + " or " + targetFileScala + " or " + targetFileScalaJava)
+    String targetFileKotlin = kotlinSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + coreModClass.toString().replaceAll("\\.", "/") + ".kt"
+    if(!(getFile(targetFileJava).exists() || getFile(targetFileScala).exists() || getFile(targetFileScalaJava).exists() || getFile(targetFileKotlin).exists())) {
+        throw new GradleException("Could not resolve \"coreModClass\"! Could not find " + targetFileJava + " or " + targetFileScala + " or " + targetFileScalaJava + " or " + targetFileKotlin)
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ plugins {
     id 'idea'
     id 'eclipse'
     id 'scala'
+    id('org.jetbrains.kotlin.jvm') version ('1.6.10') apply false
     id('org.ajoberstar.grgit') version('4.1.1')
     id('com.github.johnrengelman.shadow') version('4.0.4')
     id('com.palantir.git-version') version('0.13.0') apply false

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ plugins {
     id 'idea'
     id 'eclipse'
     id 'scala'
-    id('org.jetbrains.kotlin.jvm') version ('1.6.10')
+    id('org.jetbrains.kotlin.jvm') version ('1.6.10') apply false
     id('org.ajoberstar.grgit') version('4.1.1')
     id('com.github.johnrengelman.shadow') version('4.0.4')
     id('com.palantir.git-version') version('0.13.0') apply false
@@ -53,12 +53,6 @@ if (project.file('.git/HEAD').isFile()) {
 }
 
 apply plugin: 'forge'
-
-compileKotlin {
-    kotlinOptions {
-        jvmTarget = 1.8
-    }
-}
 
 def projectJavaVersion = JavaLanguageVersion.of(8)
 

--- a/build.gradle
+++ b/build.gradle
@@ -157,7 +157,12 @@ configurations.all {
 }
 
 // Fix Jenkins' Git: chmod a file should not be detected as a change and append a '.dirty' to the version
-'git config core.fileMode false'.execute()
+try {
+    'git config core.fileMode false'.execute()
+}
+catch (Exception e) {
+    logger.error("\u001B[31mgit isn't installed at all\u001B[0m")
+}
 
 // Pulls version first from the VERSION env and then git tag
 String identifiedVersion

--- a/build.gradle
+++ b/build.gradle
@@ -166,21 +166,24 @@ catch (Exception e) {
 
 // Pulls version first from the VERSION env and then git tag
 String identifiedVersion
+String versionOverride = System.getenv("VERSION") ?: null
 try {
-    String versionOverride = System.getenv("VERSION") ?: null
     identifiedVersion = versionOverride == null ? gitVersion() : versionOverride
 }
 catch (Exception e) {
     logger.error("\n\u001B[1;31mThis mod must be version controlled by Git AND the repository must provide at least one tag,\n" +
                  "or the VERSION override must be set! \u001B[32m(Don't download from GitHub using the ZIP option, instead\n" +
                  "clone the repository, see\u001B[33m https://gtnh.miraheze.org/wiki/Development \u001B[32mfor details.)\u001B[0m\n");
-    identifiedVersion = 'NO-GIT-TAG-SET'
+    versionOverride = 'NO-GIT-TAG-SET'
+    identifiedVersion = versionOverride
 }
 version = minecraftVersion + '-' + identifiedVersion
 String modVersion = version
 
-logger.error('\u001B[31m\u001B[7mWe hope you know what you\'re doing using\u001B[0m\u001B[1;34m ' + modVersion + '\u001B[0m\n');
-logger.error('\7\u001B[31mGoing to blindly try to use\u001B[1;34m ' + modVersion + '\u001B[0m\u001B[31m, this probably won\'t work the way you expect!!\u001B[0m\n');
+if( identifiedVersion.equals(versionOverride) ) {
+    logger.error('\u001B[31m\u001B[7mWe hope you know what you\'re doing using\u001B[0m\u001B[1;34m ' + modVersion + '\u001B[0m\n');
+    logger.error('\7\u001B[31mGoing to blindly try to use\u001B[1;34m ' + modVersion + '\u001B[0m\u001B[31m, this probably won\'t work the way you expect!!\u001B[0m\n');
+}
 
 group = modGroup
 if(project.hasProperty("customArchiveBaseName") && customArchiveBaseName) {

--- a/build.gradle
+++ b/build.gradle
@@ -167,8 +167,11 @@ try {
     version = minecraftVersion + "-" + identifiedVersion
 }
 catch (Exception e) {
-    logger.error("\u001B[1;31mThis mod must be version controlled by Git AND the repository must provide at least one tag,\nor the VERSION override must be set!\u001B[0m");
-    version = minecraftVersion + '-' + 'NO-GIT-TAG-SET'
+    logger.error("\n\u001B[1;31mThis mod must be version controlled by Git AND the repository must provide at least one tag,\n" +
+                 "or the VERSION override must be set! \u001B[32m(Don't download from GitHub using the ZIP option, instead\n" +
+                 "clone the repository, see\u001B[33m https://gtnh.miraheze.org/wiki/Development \u001B[32mfor details.)\u001B[0m\n");
+    identifiedVersion = 'NO-GIT-TAG-SET'
+    version = minecraftVersion + '-' + identifiedVersion
 }
 
 group = modGroup
@@ -209,8 +212,8 @@ minecraft {
                 replace gradleTokenVersion, versionDetails().lastTag
             }
             catch (Exception e) {
-                logger.error('\7\u001B[31mGoing to blindly try to continue, this probably won\'t work!!');
-                replace gradleTokenVersion, version
+                logger.error('\7\u001B[31mGoing to blindly try to use\u001B[1;34m ' + minecraftVersion + "-" + identifiedVersion + '\u001B[0m\u001B[31m, this probably won\'t work the way you expect!!\n');
+                replace gradleTokenVersion, minecraftVersion + "-" + identifiedVersion
             }
         }
         if(gradleTokenGroupName) {
@@ -404,7 +407,7 @@ processResources
                 "modName": modName
         }
         catch (Exception e) {
-            logger.error('\u001B[7mSeriously go setup git');
+            logger.error('\u001B[7mWe hope you know what you\'re doing using\u001B[0m\u001B[1;34m ' + version + '\u001B[0m\n');
             expand "minecraftVersion": project.minecraft.version,
                 "modVersion": version,
                 "modId": modId,

--- a/build.gradle
+++ b/build.gradle
@@ -164,15 +164,18 @@ String identifiedVersion
 try {
     String versionOverride = System.getenv("VERSION") ?: null
     identifiedVersion = versionOverride == null ? gitVersion() : versionOverride
-    version = minecraftVersion + "-" + identifiedVersion
 }
 catch (Exception e) {
     logger.error("\n\u001B[1;31mThis mod must be version controlled by Git AND the repository must provide at least one tag,\n" +
                  "or the VERSION override must be set! \u001B[32m(Don't download from GitHub using the ZIP option, instead\n" +
                  "clone the repository, see\u001B[33m https://gtnh.miraheze.org/wiki/Development \u001B[32mfor details.)\u001B[0m\n");
     identifiedVersion = 'NO-GIT-TAG-SET'
-    version = minecraftVersion + '-' + identifiedVersion
 }
+version = minecraftVersion + '-' + identifiedVersion
+String modVersion = version
+
+logger.error('\u001B[31m\u001B[7mWe hope you know what you\'re doing using\u001B[0m\u001B[1;34m ' + modVersion + '\u001B[0m\n');
+logger.error('\7\u001B[31mGoing to blindly try to use\u001B[1;34m ' + modVersion + '\u001B[0m\u001B[31m, this probably won\'t work the way you expect!!\u001B[0m\n');
 
 group = modGroup
 if(project.hasProperty("customArchiveBaseName") && customArchiveBaseName) {
@@ -208,13 +211,7 @@ minecraft {
             replace gradleTokenModName, modName
         }
         if(gradleTokenVersion) {
-            try {
-                replace gradleTokenVersion, versionDetails().lastTag
-            }
-            catch (Exception e) {
-                logger.error('\7\u001B[31mGoing to blindly try to use\u001B[1;34m ' + minecraftVersion + "-" + identifiedVersion + '\u001B[0m\u001B[31m, this probably won\'t work the way you expect!!\n');
-                replace gradleTokenVersion, minecraftVersion + "-" + identifiedVersion
-            }
+            replace gradleTokenVersion, modVersion
         }
         if(gradleTokenGroupName) {
             replace gradleTokenGroupName, modGroup
@@ -400,19 +397,10 @@ processResources
         include 'mcmod.info'
 
         // replace version and mcversion
-        try {
-            expand "minecraftVersion": project.minecraft.version,
-                "modVersion": versionDetails().lastTag,
-                "modId": modId,
-                "modName": modName
-        }
-        catch (Exception e) {
-            logger.error('\u001B[7mWe hope you know what you\'re doing using\u001B[0m\u001B[1;34m ' + version + '\u001B[0m\n');
-            expand "minecraftVersion": project.minecraft.version,
-                "modVersion": version,
-                "modId": modId,
-                "modName": modName
-        }
+        expand "minecraftVersion": project.minecraft.version,
+            "modVersion": modVersion,
+            "modId": modId,
+            "modName": modName
     }
 
     if(usesMixins.toBoolean()) {

--- a/build.gradle
+++ b/build.gradle
@@ -209,8 +209,8 @@ minecraft {
                 replace gradleTokenVersion, versionDetails().lastTag
             }
             catch (Exception e) {
-                logger.error('\7\u001B[31mGoing to blindly try to continue, this most certainly won\'t work!!');
-                replace gradleTokenVersion, 'NO-GIT-TAG-SET'
+                logger.error('\7\u001B[31mGoing to blindly try to continue, this probably won\'t work!!');
+                replace gradleTokenVersion, version
             }
         }
         if(gradleTokenGroupName) {
@@ -406,7 +406,7 @@ processResources
         catch (Exception e) {
             logger.error('\u001B[7mSeriously go setup git');
             expand "minecraftVersion": project.minecraft.version,
-                "modVersion": 'NO-GIT-TAG-SET',
+                "modVersion": version,
                 "modId": modId,
                 "modName": modName
         }

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1643020202
+//version: 1643844119
 /*
 DO NOT CHANGE THIS FILE!
 
@@ -40,11 +40,15 @@ plugins {
     id 'idea'
     id 'eclipse'
     id 'scala'
-    id("org.ajoberstar.grgit") version("3.1.1")
-    id("com.github.johnrengelman.shadow") version("4.0.4")
-    id("com.palantir.git-version") version("0.12.3")
-    id('de.undercouch.download') version('4.1.2')
-    id("maven-publish")
+    id('org.ajoberstar.grgit') version('4.1.1')
+    id('com.github.johnrengelman.shadow') version('4.0.4')
+    id('com.palantir.git-version') version('0.13.0') apply false
+    id('de.undercouch.download') version('5.0.1')
+    id('maven-publish')
+}
+
+if (project.file('.git/HEAD').isFile()) {
+    apply plugin: 'com.palantir.git-version'
 }
 
 apply plugin: 'forge'
@@ -163,7 +167,8 @@ try {
     version = minecraftVersion + "-" + identifiedVersion
 }
 catch (Exception e) {
-    throw new IllegalStateException("This mod must be version controlled by Git AND the repository must provide at least one tag, or the VERSION override must be set!");
+    logger.error("\u001B[1;31mThis mod must be version controlled by Git AND the repository must provide at least one tag,\nor the VERSION override must be set!\u001B[0m");
+    version = minecraftVersion + '-' + 'NO-GIT-TAG-SET'
 }
 
 group = modGroup
@@ -200,7 +205,13 @@ minecraft {
             replace gradleTokenModName, modName
         }
         if(gradleTokenVersion) {
-            replace gradleTokenVersion, versionDetails().lastTag
+            try {
+                replace gradleTokenVersion, versionDetails().lastTag
+            }
+            catch (Exception e) {
+                logger.error('\7\u001B[31mGoing to blindly try to continue, this most certainly won\'t work!!');
+                replace gradleTokenVersion, 'NO-GIT-TAG-SET'
+            }
         }
         if(gradleTokenGroupName) {
             replace gradleTokenGroupName, modGroup
@@ -380,16 +391,25 @@ processResources
     // this will ensure that this task is redone when the versions change.
     inputs.property "version", project.version
     inputs.property "mcversion", project.minecraft.version
-
+    
     // replace stuff in mcmod.info, nothing else
     from(sourceSets.main.resources.srcDirs) {
         include 'mcmod.info'
 
         // replace version and mcversion
-        expand "minecraftVersion": project.minecraft.version,
+        try {
+            expand "minecraftVersion": project.minecraft.version,
                 "modVersion": versionDetails().lastTag,
                 "modId": modId,
                 "modName": modName
+        }
+        catch (Exception e) {
+            logger.error('\u001B[7mSeriously go setup git');
+            expand "minecraftVersion": project.minecraft.version,
+                "modVersion": 'NO-GIT-TAG-SET',
+                "modId": modId,
+                "modName": modName
+        }
     }
 
     if(usesMixins.toBoolean()) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -37,7 +37,7 @@ gradleTokenGroupName = GRADLETOKEN_GROUPNAME
 # Example value: apiPackage = api + modGroup = com.myname.mymodid -> com.myname.mymodid.api
 apiPackage =
 
-# Specify the configuration file for Forge's access transformers here. I must be placed into /src/main/resources/META-INF/
+# Specify the configuration file for Forge's access transformers here. It must be placed into /src/main/resources/META-INF/
 # Example value: mymodid_at.cfg
 accessTransformersFile =
 


### PR DESCRIPTION
This could probably be done cleaner but:

1. If `.git/HEAD` doesn't exist, don't load the git plugin
2. If `VERSION` isn't set and there's a git error, warn that you probably downloaded the zip
3. If you set `VERSION` actually use it

Also updated some plugins to current versions (the issue with Java 8 and `grgit` is fixed. Didn't touch `shadow` as there are likely other issues there.