### PR TITLE
Allow running gradle with newer java

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,10 +92,6 @@ idea {
 }
 apply from: Blowdryer.file('spotless.gradle')
 
-if(JavaVersion.current() != JavaVersion.VERSION_1_8) {
-    throw new GradleException("This project requires Java 8, but it's running on " + JavaVersion.current())
-}
-
 checkPropertyExists("modName")
 checkPropertyExists("modId")
 checkPropertyExists("modGroup")


### PR DESCRIPTION
Toolchain is still set to java 8 so runClient, setupDecompWorkspace etc. work by finding the system installation of java 8 (or even downloading adoptjdk8 if not found according to <https://docs.gradle.org/current/userguide/toolchains.html>)