### PR TITLE
Fix file not found if no mixins exist

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -397,7 +397,7 @@ jar {
 }
 
 reobf {
-    if(usesMixins.toBoolean()) {
+    if(usesMixins.toBoolean() && file(mixinSrg).exists()) {
         addExtraSrgFile mixinSrg
     }
 }


### PR DESCRIPTION
Plugin can exist but no mixins actually created 