### PR TITLE
Fix hodgepodge build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,11 @@ buildscript {
             url 'https://maven.minecraftforge.net'
         }
         maven {
+            // GTNH ForgeGradle Fork
+            name = "GTNH Maven"
+            url = "http://jenkins.usrv.eu:8081/nexus/content/groups/public/"
+        }
+        maven {
             name 'sonatype'
             url 'https://oss.sonatype.org/content/repositories/snapshots/'
         }
@@ -34,13 +39,9 @@ buildscript {
             name 'Scala CI dependencies'
             url 'https://repo1.maven.org/maven2/'
         }
-        maven {
-            name 'jitpack'
-            url 'https://jitpack.io'
-        }
     }
     dependencies {
-        classpath 'com.github.GTNewHorizons:ForgeGradle:1.2.7'
+        classpath 'net.minecraftforge.gradle:ForgeGradle:1.2.9'
     }
 }
 plugins {
@@ -49,17 +50,17 @@ plugins {
     id 'eclipse'
     id 'scala'
     id 'maven-publish'
-    id 'org.jetbrains.kotlin.jvm'        version '1.5.30'       apply false
-    id 'org.jetbrains.kotlin.kapt'       version '1.5.30'       apply false
-    id 'com.google.devtools.ksp'         version '1.5.30-1.0.0' apply false
-    id 'org.ajoberstar.grgit'            version '4.1.1'
+    id 'org.jetbrains.kotlin.jvm' version '1.5.30' apply false
+    id 'org.jetbrains.kotlin.kapt' version '1.5.30' apply false
+    id 'com.google.devtools.ksp' version '1.5.30-1.0.0' apply false
+    id 'org.ajoberstar.grgit' version '4.1.1'
     id 'com.github.johnrengelman.shadow' version '4.0.4'
-    id 'com.palantir.git-version'        version '0.13.0'       apply false
-    id 'de.undercouch.download'          version '5.0.1'
-    id 'com.github.gmazzo.buildconfig'   version '3.0.3'        apply false
-    id 'com.diffplug.spotless'           version '6.7.2'        apply false
+    id 'com.palantir.git-version' version '0.13.0' apply false
+    id 'de.undercouch.download' version '5.0.1'
+    id 'com.github.gmazzo.buildconfig' version '3.0.3' apply false
+    id 'com.diffplug.spotless' version '6.7.2' apply false
 }
-if(verifySettingsGradle() || verifyGitAttributes())
+if (verifySettingsGradle() || verifyGitAttributes())
     throw new GradleException("Settings has been updated, please re-run task.")
 
 dependencies {
@@ -99,7 +100,7 @@ if (!disableSpotless) {
     apply from: Blowdryer.file('spotless.gradle')
 }
 
-if(JavaVersion.current() != JavaVersion.VERSION_1_8) {
+if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
     throw new GradleException("This project requires Java 8, but it's running on " + JavaVersion.current())
 }
 
@@ -136,53 +137,53 @@ String kotlinSourceDir = "src/main/kotlin/"
 String targetPackageJava = javaSourceDir + modGroup.toString().replaceAll("\\.", "/")
 String targetPackageScala = scalaSourceDir + modGroup.toString().replaceAll("\\.", "/")
 String targetPackageKotlin = kotlinSourceDir + modGroup.toString().replaceAll("\\.", "/")
-if(!(getFile(targetPackageJava).exists() || getFile(targetPackageScala).exists() || getFile(targetPackageKotlin).exists())) {
+if (!(getFile(targetPackageJava).exists() || getFile(targetPackageScala).exists() || getFile(targetPackageKotlin).exists())) {
     throw new GradleException("Could not resolve \"modGroup\"! Could not find " + targetPackageJava + " or " + targetPackageScala + " or " + targetPackageKotlin)
 }
 
-if(apiPackage) {
+if (apiPackage) {
     targetPackageJava = javaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + apiPackage.toString().replaceAll("\\.", "/")
     targetPackageScala = scalaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + apiPackage.toString().replaceAll("\\.", "/")
     targetPackageKotlin = kotlinSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + apiPackage.toString().replaceAll("\\.", "/")
-    if(!(getFile(targetPackageJava).exists() || getFile(targetPackageScala).exists() || getFile(targetPackageKotlin).exists())) {
+    if (!(getFile(targetPackageJava).exists() || getFile(targetPackageScala).exists() || getFile(targetPackageKotlin).exists())) {
         throw new GradleException("Could not resolve \"apiPackage\"! Could not find " + targetPackageJava + " or " + targetPackageScala + " or " + targetPackageKotlin)
     }
 }
 
-if(accessTransformersFile) {
+if (accessTransformersFile) {
     String targetFile = "src/main/resources/META-INF/" + accessTransformersFile
-    if(!getFile(targetFile).exists()) {
+    if (!getFile(targetFile).exists()) {
         throw new GradleException("Could not resolve \"accessTransformersFile\"! Could not find " + targetFile)
     }
 }
 
-if(usesMixins.toBoolean()) {
-    if(mixinsPackage.isEmpty() || mixinPlugin.isEmpty()) {
+if (usesMixins.toBoolean()) {
+    if (mixinsPackage.isEmpty() || mixinPlugin.isEmpty()) {
         throw new GradleException("\"mixinPlugin\" requires \"mixinsPackage\" and \"mixinPlugin\" to be set!")
     }
 
     targetPackageJava = javaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + mixinsPackage.toString().replaceAll("\\.", "/")
     targetPackageScala = scalaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + mixinsPackage.toString().replaceAll("\\.", "/")
     targetPackageKotlin = kotlinSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + mixinsPackage.toString().replaceAll("\\.", "/")
-    if(!(getFile(targetPackageJava).exists() || getFile(targetPackageScala).exists() || getFile(targetPackageKotlin).exists())) {
-        throw new GradleException("Could not resolve \"mixinsPackage\"! Could not find " + targetPackageJava + " or " + targetPackageScala  + " or " + targetPackageKotlin)
+    if (!(getFile(targetPackageJava).exists() || getFile(targetPackageScala).exists() || getFile(targetPackageKotlin).exists())) {
+        throw new GradleException("Could not resolve \"mixinsPackage\"! Could not find " + targetPackageJava + " or " + targetPackageScala + " or " + targetPackageKotlin)
     }
 
     String targetFileJava = javaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + mixinPlugin.toString().replaceAll("\\.", "/") + ".java"
     String targetFileScala = scalaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + mixinPlugin.toString().replaceAll("\\.", "/") + ".scala"
     String targetFileScalaJava = scalaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + mixinPlugin.toString().replaceAll("\\.", "/") + ".java"
     String targetFileKotlin = kotlinSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + mixinPlugin.toString().replaceAll("\\.", "/") + ".kt"
-    if(!(getFile(targetFileJava).exists() || getFile(targetFileScala).exists() || getFile(targetFileScalaJava).exists() || getFile(targetFileKotlin).exists())) {
+    if (!(getFile(targetFileJava).exists() || getFile(targetFileScala).exists() || getFile(targetFileScalaJava).exists() || getFile(targetFileKotlin).exists())) {
         throw new GradleException("Could not resolve \"mixinPlugin\"! Could not find " + targetFileJava + " or " + targetFileScala + " or " + targetFileScalaJava + " or " + targetFileKotlin)
     }
 }
 
-if(coreModClass) {
+if (coreModClass) {
     String targetFileJava = javaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + coreModClass.toString().replaceAll("\\.", "/") + ".java"
     String targetFileScala = scalaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + coreModClass.toString().replaceAll("\\.", "/") + ".scala"
     String targetFileScalaJava = scalaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + coreModClass.toString().replaceAll("\\.", "/") + ".java"
     String targetFileKotlin = kotlinSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + coreModClass.toString().replaceAll("\\.", "/") + ".kt"
-    if(!(getFile(targetFileJava).exists() || getFile(targetFileScala).exists() || getFile(targetFileScalaJava).exists() || getFile(targetFileKotlin).exists())) {
+    if (!(getFile(targetFileJava).exists() || getFile(targetFileScala).exists() || getFile(targetFileScalaJava).exists() || getFile(targetFileKotlin).exists())) {
         throw new GradleException("Could not resolve \"coreModClass\"! Could not find " + targetFileJava + " or " + targetFileScala + " or " + targetFileScalaJava + " or " + targetFileKotlin)
     }
 }
@@ -211,10 +212,10 @@ try {
 }
 catch (Exception ignored) {
     out.style(Style.Failure).text(
-            'This mod must be version controlled by Git AND the repository must provide at least one tag,\n' +
+        'This mod must be version controlled by Git AND the repository must provide at least one tag,\n' +
             'or the VERSION override must be set! ').style(Style.SuccessHeader).text('(Do NOT download from GitHub using the ZIP option, instead\n' +
-            'clone the repository, see ').style(Style.Info).text('https://gtnh.miraheze.org/wiki/Development').style(Style.SuccessHeader).println(' for details.)'
-            )
+        'clone the repository, see ').style(Style.Info).text('https://gtnh.miraheze.org/wiki/Development').style(Style.SuccessHeader).println(' for details.)'
+    )
     versionOverride = 'NO-GIT-TAG-SET'
     identifiedVersion = versionOverride
 }
@@ -223,15 +224,14 @@ ext {
     modVersion = identifiedVersion
 }
 
-if(identifiedVersion == versionOverride) {
+if (identifiedVersion == versionOverride) {
     out.style(Style.Failure).text('Override version to ').style(Style.Identifier).text(modVersion).style(Style.Failure).println('!\7')
 }
 
 group = modGroup
-if(project.hasProperty("customArchiveBaseName") && customArchiveBaseName) {
+if (project.hasProperty("customArchiveBaseName") && customArchiveBaseName) {
     archivesBaseName = customArchiveBaseName
-}
-else {
+} else {
     archivesBaseName = modId
 }
 
@@ -257,16 +257,16 @@ minecraft {
 
     if (replaceGradleTokenInFile) {
         replaceIn replaceGradleTokenInFile
-        if(gradleTokenModId) {
+        if (gradleTokenModId) {
             replace gradleTokenModId, modId
         }
-        if(gradleTokenModName) {
+        if (gradleTokenModName) {
             replace gradleTokenModName, modName
         }
-        if(gradleTokenVersion) {
+        if (gradleTokenVersion) {
             replace gradleTokenVersion, modVersion
         }
-        if(gradleTokenGroupName) {
+        if (gradleTokenGroupName) {
             replace gradleTokenGroupName, modGroup
         }
     }
@@ -275,7 +275,7 @@ minecraft {
         args(arguments)
         jvmArgs(jvmArguments)
 
-        if(developmentEnvironmentUserName) {
+        if (developmentEnvironmentUserName) {
             args("--username", developmentEnvironmentUserName)
         }
     }
@@ -286,7 +286,7 @@ minecraft {
     }
 }
 
-if(file('addon.gradle').exists()) {
+if (file('addon.gradle').exists()) {
     apply from: 'addon.gradle'
 }
 
@@ -303,7 +303,7 @@ repositories {
         name 'Overmind forge repo mirror'
         url 'https://gregtech.overminddl1.com/'
     }
-    if(usesMixins.toBoolean() || forceEnableMixins) {
+    if (usesMixins.toBoolean() || forceEnableMixins) {
         maven {
             name 'sponge'
             url 'https://repo.spongepowered.org/repository/maven-public'
@@ -315,13 +315,13 @@ repositories {
 }
 
 dependencies {
-    if(usesMixins.toBoolean()) {
+    if (usesMixins.toBoolean()) {
         annotationProcessor('org.ow2.asm:asm-debug-all:5.0.3')
         annotationProcessor('com.google.guava:guava:24.1.1-jre')
         annotationProcessor('com.google.code.gson:gson:2.8.6')
         annotationProcessor('org.spongepowered:mixin:0.8-SNAPSHOT')
     }
-    if(usesMixins.toBoolean() || forceEnableMixins) {
+    if (usesMixins.toBoolean() || forceEnableMixins) {
         // using 0.8 to workaround a issue in 0.7 which fails mixin application
         compile('com.github.GTNewHorizons:SpongePoweredMixin:0.7.12-GTNH') {
             // Mixin includes a lot of dependencies that are too up-to-date
@@ -397,20 +397,20 @@ jar {
         attributes(getManifestAttributes())
     }
 
-    if(usesShadowedDependencies.toBoolean()) {
+    if (usesShadowedDependencies.toBoolean()) {
         dependsOn(shadowJar)
         enabled = false
     }
 }
 
 reobf {
-    if(usesMixins.toBoolean()) {
+    if (usesMixins.toBoolean()) {
         addExtraSrgFile mixinSrg
     }
 }
 
 afterEvaluate {
-    if(usesMixins.toBoolean()) {
+    if (usesMixins.toBoolean()) {
         tasks.compileJava {
             options.compilerArgs += [
                 "-AreobfSrgFile=${tasks.reobf.srg}",
@@ -425,7 +425,7 @@ afterEvaluate {
 }
 
 runClient {
-    if(developmentEnvironmentUserName) {
+    if (developmentEnvironmentUserName) {
         arguments += [
             "--username",
             developmentEnvironmentUserName
@@ -443,10 +443,10 @@ runServer {
 
 tasks.withType(JavaExec).configureEach {
     javaLauncher.set(
-            javaToolchains.launcherFor {
-                languageVersion = projectJavaVersion
-            }
-            )
+        javaToolchains.launcherFor {
+            languageVersion = projectJavaVersion
+        }
+    )
 }
 
 processResources {
@@ -461,12 +461,12 @@ processResources {
 
         // replace modVersion and minecraftVersion
         expand "minecraftVersion": project.minecraft.version,
-        "modVersion": modVersion,
-        "modId": modId,
-        "modName": modName
+            "modVersion": modVersion,
+            "modId": modId,
+            "modName": modName
     }
 
-    if(usesMixins.toBoolean()) {
+    if (usesMixins.toBoolean()) {
         from refMap
     }
 
@@ -479,31 +479,31 @@ processResources {
 
 def getManifestAttributes() {
     def manifestAttributes = [:]
-    if(!containsMixinsAndOrCoreModOnly.toBoolean() && (usesMixins.toBoolean() || coreModClass)) {
+    if (!containsMixinsAndOrCoreModOnly.toBoolean() && (usesMixins.toBoolean() || coreModClass)) {
         manifestAttributes += ["FMLCorePluginContainsFMLMod": true]
     }
 
-    if(accessTransformersFile) {
-        manifestAttributes += ["FMLAT" : accessTransformersFile.toString()]
+    if (accessTransformersFile) {
+        manifestAttributes += ["FMLAT": accessTransformersFile.toString()]
     }
 
-    if(coreModClass) {
+    if (coreModClass) {
         manifestAttributes += ["FMLCorePlugin": modGroup + "." + coreModClass]
     }
 
-    if(usesMixins.toBoolean()) {
+    if (usesMixins.toBoolean()) {
         manifestAttributes += [
-            "TweakClass" : "org.spongepowered.asm.launch.MixinTweaker",
-            "MixinConfigs" : "mixins." + modId + ".json",
-            "ForceLoadAsMod" : !containsMixinsAndOrCoreModOnly.toBoolean()
+            "TweakClass"    : "org.spongepowered.asm.launch.MixinTweaker",
+            "MixinConfigs"  : "mixins." + modId + ".json",
+            "ForceLoadAsMod": !containsMixinsAndOrCoreModOnly.toBoolean()
         ]
     }
     return manifestAttributes
 }
 
 task sourcesJar(type: Jar) {
-    from (sourceSets.main.allSource)
-    from (file("$projectDir/LICENSE"))
+    from(sourceSets.main.allSource)
+    from(file("$projectDir/LICENSE"))
     getArchiveClassifier().set('sources')
 }
 
@@ -553,22 +553,22 @@ task devJar(type: Jar) {
         attributes(getManifestAttributes())
     }
 
-    if(usesShadowedDependencies.toBoolean()) {
+    if (usesShadowedDependencies.toBoolean()) {
         dependsOn(circularResolverJar)
         enabled = false
     }
 }
 
 task apiJar(type: Jar) {
-    from (sourceSets.main.allSource) {
+    from(sourceSets.main.allSource) {
         include modGroup.toString().replaceAll("\\.", "/") + "/" + apiPackage.toString().replaceAll("\\.", "/") + '/**'
     }
 
-    from (sourceSets.main.output) {
+    from(sourceSets.main.output) {
         include modGroup.toString().replaceAll("\\.", "/") + "/" + apiPackage.toString().replaceAll("\\.", "/") + '/**'
     }
 
-    from (sourceSets.main.resources.srcDirs) {
+    from(sourceSets.main.resources.srcDirs) {
         include("LICENSE")
     }
 
@@ -576,11 +576,11 @@ task apiJar(type: Jar) {
 }
 
 artifacts {
-    if(!noPublishedSources) {
+    if (!noPublishedSources) {
         archives sourcesJar
     }
     archives devJar
-    if(apiPackage) {
+    if (apiPackage) {
         archives apiJar
     }
 }
@@ -598,10 +598,10 @@ publishing {
     publications {
         maven(MavenPublication) {
             from components.java
-            if(usesShadowedDependencies.toBoolean()) {
+            if (usesShadowedDependencies.toBoolean()) {
                 artifact source: shadowJar, classifier: ""
             }
-            if(!noPublishedSources) {
+            if (!noPublishedSources) {
                 artifact source: sourcesJar, classifier: "sources"
             }
             artifact source: usesShadowedDependencies.toBoolean() ? shadowDevJar : devJar, classifier: "dev"
@@ -616,11 +616,11 @@ publishing {
 
             // remove extra garbage from minecraft and minecraftDeps configuration
             pom.withXml {
-                def badArtifacts = [:].withDefault {[] as Set<String>}
+                def badArtifacts = [:].withDefault { [] as Set<String> }
                 for (configuration in [
-                            projectConfigs.minecraft,
-                            projectConfigs.minecraftDeps
-                        ]) {
+                    projectConfigs.minecraft,
+                    projectConfigs.minecraftDeps
+                ]) {
                     for (dependency in configuration.allDependencies) {
                         badArtifacts[dependency.group == null ? "" : dependency.group] += dependency.name
                     }
@@ -654,7 +654,7 @@ task updateBuildScript {
     doLast {
         if (performBuildScriptUpdate(projectDir.toString())) return
 
-            print("Build script already up-to-date!")
+        print("Build script already up-to-date!")
     }
 }
 
@@ -669,9 +669,11 @@ if (!project.getGradle().startParameter.isOffline() && isNewBuildScriptVersionAv
 static URL availableBuildScriptUrl() {
     new URL("https://raw.githubusercontent.com/GTNewHorizons/ExampleMod1.7.10/master/build.gradle")
 }
+
 static URL exampleSettingsGradleUrl() {
     new URL("https://raw.githubusercontent.com/GTNewHorizons/ExampleMod1.7.10/master/settings.gradle.example")
 }
+
 static URL exampleGitAttributesUrl() {
     new URL("https://raw.githubusercontent.com/GTNewHorizons/ExampleMod1.7.10/master/.gitattributes")
 }
@@ -706,7 +708,7 @@ boolean performBuildScriptUpdate(String projectDir) {
         def buildscriptFile = getFile("build.gradle")
         availableBuildScriptUrl().withInputStream { i -> buildscriptFile.withOutputStream { it << i } }
         out.style(Style.Success).print("Build script updated. Please REIMPORT the project or RESTART your IDE!")
-        if(verifySettingsGradle() || verifyGitAttributes())
+        if (verifySettingsGradle() || verifyGitAttributes())
             throw new GradleException("Settings has been updated, please re-run task.")
         return true
     }
@@ -727,7 +729,7 @@ boolean isNewBuildScriptVersionAvailable(String projectDir) {
 
 static String getVersionHash(String buildScriptContent) {
     String versionLine = buildScriptContent.find("^//version: [a-z0-9]*")
-    if(versionLine != null) {
+    if (versionLine != null) {
         return versionLine.split(": ").last()
     }
     return ""
@@ -753,210 +755,210 @@ task deobfParams {
             overwrite false
         }
 
-        if(!file(paramsCSV).exists()) {
+        if (!file(paramsCSV).exists()) {
             println("Extracting MCP archive ...")
             unzip(mcpZIP, mcpDir)
         }
 
         println("Parsing params.csv ...")
         Map<String, String> params = new HashMap<>()
-        Files.lines(Paths.get(paramsCSV)).forEach{line ->
+        Files.lines(Paths.get(paramsCSV)).forEach { line ->
             String[] cells = line.split(",")
-            if(cells.length > 2 && cells[0].matches("p_i?\\d+_\\d+_")) {
+            if (cells.length > 2 && cells[0].matches("p_i?\\d+_\\d+_")) {
                 params.put(cells[0], cells[1])
             }
         }
 
         out.style(Style.Success).println("Modified ${replaceParams(file("$projectDir/src/main/java"), params)} files!")
-    out.style(Style.Failure).println("Don't forget to verify that the code still works as before!\n It could be broken due to duplicate variables existing now\n or parameters taking priority over other variables.")
-}
+        out.style(Style.Failure).println("Don't forget to verify that the code still works as before!\n It could be broken due to duplicate variables existing now\n or parameters taking priority over other variables.")
+    }
 }
 
 static int replaceParams(File file, Map<String, String> params) {
-int fileCount = 0
+    int fileCount = 0
 
-if(file.isDirectory()) {
-    for(File f : file.listFiles()) {
-        fileCount += replaceParams(f, params)
+    if (file.isDirectory()) {
+        for (File f : file.listFiles()) {
+            fileCount += replaceParams(f, params)
+        }
+        return fileCount
     }
-    return fileCount
-}
-println("Visiting ${file.getName()} ...")
-try {
-    String content = new String(Files.readAllBytes(file.toPath()))
-    int hash = content.hashCode()
-    params.forEach{key, value ->
-        content = content.replaceAll(key, value)
+    println("Visiting ${file.getName()} ...")
+    try {
+        String content = new String(Files.readAllBytes(file.toPath()))
+        int hash = content.hashCode()
+        params.forEach { key, value ->
+            content = content.replaceAll(key, value)
+        }
+        if (hash != content.hashCode()) {
+            Files.write(file.toPath(), content.getBytes("UTF-8"))
+            return 1
+        }
+    } catch (Exception e) {
+        e.printStackTrace()
     }
-    if(hash != content.hashCode()) {
-        Files.write(file.toPath(), content.getBytes("UTF-8"))
-        return 1
-    }
-} catch(Exception e) {
-    e.printStackTrace()
-}
-return 0
+    return 0
 }
 
 // Credit: bitsnaps (https://gist.github.com/bitsnaps/00947f2dce66f4bbdabc67d7e7b33681)
 static unzip(String zipFileName, String outputDir) {
-byte[] buffer = new byte[16384]
-ZipInputStream zis = new ZipInputStream(new FileInputStream(zipFileName))
-ZipEntry zipEntry = zis.getNextEntry()
-while (zipEntry != null) {
-    File newFile = new File(outputDir + File.separator, zipEntry.name)
-    if (zipEntry.isDirectory()) {
-        if (!newFile.isDirectory() && !newFile.mkdirs()) {
-            throw new IOException("Failed to create directory $newFile")
+    byte[] buffer = new byte[16384]
+    ZipInputStream zis = new ZipInputStream(new FileInputStream(zipFileName))
+    ZipEntry zipEntry = zis.getNextEntry()
+    while (zipEntry != null) {
+        File newFile = new File(outputDir + File.separator, zipEntry.name)
+        if (zipEntry.isDirectory()) {
+            if (!newFile.isDirectory() && !newFile.mkdirs()) {
+                throw new IOException("Failed to create directory $newFile")
+            }
+        } else {
+            // fix for Windows-created archives
+            File parent = newFile.parentFile
+            if (!parent.isDirectory() && !parent.mkdirs()) {
+                throw new IOException("Failed to create directory $parent")
+            }
+            // write file content
+            FileOutputStream fos = new FileOutputStream(newFile)
+            int len = 0
+            while ((len = zis.read(buffer)) > 0) {
+                fos.write(buffer, 0, len)
+            }
+            fos.close()
         }
-    } else {
-        // fix for Windows-created archives
-        File parent = newFile.parentFile
-        if (!parent.isDirectory() && !parent.mkdirs()) {
-            throw new IOException("Failed to create directory $parent")
-        }
-        // write file content
-        FileOutputStream fos = new FileOutputStream(newFile)
-        int len = 0
-        while ((len = zis.read(buffer)) > 0) {
-            fos.write(buffer, 0, len)
-        }
-        fos.close()
+        zipEntry = zis.getNextEntry()
     }
-    zipEntry = zis.getNextEntry()
-}
-zis.closeEntry()
-zis.close()
+    zis.closeEntry()
+    zis.close()
 }
 
 configure(deobfParams) {
-group = 'forgegradle'
-description = 'Rename all obfuscated parameter names inherited from Minecraft classes'
+    group = 'forgegradle'
+    description = 'Rename all obfuscated parameter names inherited from Minecraft classes'
 }
 
 // Dependency Deobfuscation
 
 def deobf(String sourceURL) {
-try {
-    URL url = new URL(sourceURL)
-    String fileName = url.getFile()
+    try {
+        URL url = new URL(sourceURL)
+        String fileName = url.getFile()
 
-    //get rid of directories:
-    int lastSlash = fileName.lastIndexOf("/")
-    if(lastSlash > 0) {
-        fileName = fileName.substring(lastSlash + 1)
-    }
-    //get rid of extension:
-    if(fileName.endsWith(".jar") || fileName.endsWith(".litemod")) {
-        fileName = fileName.substring(0, fileName.lastIndexOf("."))
-    }
+        //get rid of directories:
+        int lastSlash = fileName.lastIndexOf("/")
+        if (lastSlash > 0) {
+            fileName = fileName.substring(lastSlash + 1)
+        }
+        //get rid of extension:
+        if (fileName.endsWith(".jar") || fileName.endsWith(".litemod")) {
+            fileName = fileName.substring(0, fileName.lastIndexOf("."))
+        }
 
-    String hostName = url.getHost()
-    if(hostName.startsWith("www.")) {
-        hostName = hostName.substring(4)
-    }
-    List parts = Arrays.asList(hostName.split("\\."))
-    Collections.reverse(parts)
-    hostName = String.join(".", parts)
+        String hostName = url.getHost()
+        if (hostName.startsWith("www.")) {
+            hostName = hostName.substring(4)
+        }
+        List parts = Arrays.asList(hostName.split("\\."))
+        Collections.reverse(parts)
+        hostName = String.join(".", parts)
 
-    return deobf(sourceURL, "$hostName/$fileName")
-} catch(Exception e) {
-    return deobf(sourceURL, "deobf/${sourceURL.hashCode()}")
-}
+        return deobf(sourceURL, "$hostName/$fileName")
+    } catch (Exception e) {
+        return deobf(sourceURL, "deobf/${sourceURL.hashCode()}")
+    }
 }
 
 // The method above is to be preferred. Use this method if the filename is not at the end of the URL.
 def deobf(String sourceURL, String rawFileName) {
-String bon2Version = "2.5.1"
-String fileName = URLDecoder.decode(rawFileName, "UTF-8")
-String cacheDir = "$project.gradle.gradleUserHomeDir/caches"
-String bon2Dir = "$cacheDir/forge_gradle/deobf"
-String bon2File = "$bon2Dir/BON2-${bon2Version}.jar"
-String obfFile = "$cacheDir/modules-2/files-2.1/${fileName}.jar"
-String deobfFile = "$cacheDir/modules-2/files-2.1/${fileName}-deobf.jar"
+    String bon2Version = "2.5.1"
+    String fileName = URLDecoder.decode(rawFileName, "UTF-8")
+    String cacheDir = "$project.gradle.gradleUserHomeDir/caches"
+    String bon2Dir = "$cacheDir/forge_gradle/deobf"
+    String bon2File = "$bon2Dir/BON2-${bon2Version}.jar"
+    String obfFile = "$cacheDir/modules-2/files-2.1/${fileName}.jar"
+    String deobfFile = "$cacheDir/modules-2/files-2.1/${fileName}-deobf.jar"
 
-if(file(deobfFile).exists()) {
+    if (file(deobfFile).exists()) {
+        return files(deobfFile)
+    }
+
+    String mappingsVer
+    String remoteMappings = project.hasProperty('remoteMappings') ? project.remoteMappings : 'https://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/'
+    if (remoteMappings) {
+        String id = "${forgeVersion.split("\\.")[3]}-$minecraftVersion"
+        String mappingsZIP = "$cacheDir/forge_gradle/maven_downloader/de/oceanlabs/mcp/mcp_snapshot_nodoc/$id/mcp_snapshot_nodoc-${id}.zip"
+
+        zipMappings(mappingsZIP, remoteMappings, bon2Dir)
+
+        mappingsVer = "snapshot_$id"
+    } else {
+        mappingsVer = "${channel}_$mappingsVersion"
+    }
+
+    download.run {
+        src "http://jenkins.usrv.eu:8081/nexus/content/repositories/releases/com/github/parker8283/BON2/$bon2Version-CUSTOM/BON2-$bon2Version-CUSTOM-all.jar"
+        dest bon2File
+        quiet true
+        overwrite false
+    }
+
+    download.run {
+        src sourceURL
+        dest obfFile
+        quiet true
+        overwrite false
+    }
+
+    exec {
+        commandLine 'java', '-jar', bon2File, '--inputJar', obfFile, '--outputJar', deobfFile, '--mcVer', minecraftVersion, '--mappingsVer', mappingsVer, '--notch'
+        workingDir bon2Dir
+        standardOutput = new FileOutputStream("${deobfFile}.log")
+    }
+
     return files(deobfFile)
 }
 
-String mappingsVer
-String remoteMappings = project.hasProperty('remoteMappings') ? project.remoteMappings : 'https://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/'
-if(remoteMappings) {
-    String id = "${forgeVersion.split("\\.")[3]}-$minecraftVersion"
-    String mappingsZIP = "$cacheDir/forge_gradle/maven_downloader/de/oceanlabs/mcp/mcp_snapshot_nodoc/$id/mcp_snapshot_nodoc-${id}.zip"
-
-    zipMappings(mappingsZIP, remoteMappings, bon2Dir)
-
-    mappingsVer = "snapshot_$id"
-} else {
-    mappingsVer = "${channel}_$mappingsVersion"
-}
-
-download.run {
-    src "http://jenkins.usrv.eu:8081/nexus/content/repositories/releases/com/github/parker8283/BON2/$bon2Version-CUSTOM/BON2-$bon2Version-CUSTOM-all.jar"
-    dest bon2File
-    quiet true
-    overwrite false
-}
-
-download.run {
-    src sourceURL
-    dest obfFile
-    quiet true
-    overwrite false
-}
-
-exec {
-    commandLine 'java', '-jar', bon2File, '--inputJar', obfFile, '--outputJar', deobfFile, '--mcVer', minecraftVersion, '--mappingsVer', mappingsVer, '--notch'
-    workingDir bon2Dir
-    standardOutput = new FileOutputStream("${deobfFile}.log")
-}
-
-return files(deobfFile)
-}
-
 def zipMappings(String zipPath, String url, String bon2Dir) {
-File zipFile = new File(zipPath)
-if(zipFile.exists()) {
-    return
-}
+    File zipFile = new File(zipPath)
+    if (zipFile.exists()) {
+        return
+    }
 
-String fieldsCache = "$bon2Dir/data/fields.csv"
-String methodsCache = "$bon2Dir/data/methods.csv"
+    String fieldsCache = "$bon2Dir/data/fields.csv"
+    String methodsCache = "$bon2Dir/data/methods.csv"
 
-download.run {
-    src "${url}fields.csv"
-    dest fieldsCache
-    quiet true
-}
-download.run {
-    src "${url}methods.csv"
-    dest methodsCache
-    quiet true
-}
+    download.run {
+        src "${url}fields.csv"
+        dest fieldsCache
+        quiet true
+    }
+    download.run {
+        src "${url}methods.csv"
+        dest methodsCache
+        quiet true
+    }
 
-zipFile.getParentFile().mkdirs()
-ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(zipFile))
+    zipFile.getParentFile().mkdirs()
+    ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(zipFile))
 
-zos.putNextEntry(new ZipEntry("fields.csv"))
-Files.copy(Paths.get(fieldsCache), zos)
-zos.closeEntry()
+    zos.putNextEntry(new ZipEntry("fields.csv"))
+    Files.copy(Paths.get(fieldsCache), zos)
+    zos.closeEntry()
 
-zos.putNextEntry(new ZipEntry("methods.csv"))
-Files.copy(Paths.get(methodsCache), zos)
-zos.closeEntry()
+    zos.putNextEntry(new ZipEntry("methods.csv"))
+    Files.copy(Paths.get(methodsCache), zos)
+    zos.closeEntry()
 
-zos.close()
+    zos.close()
 }
 
 // Helper methods
 
 def checkPropertyExists(String propertyName) {
-if (!project.hasProperty(propertyName)) {
-    throw new GradleException("This project requires a property \"" + propertyName + "\"! Please add it your \"gradle.properties\". You can find all properties and their description here: https://github.com/GTNewHorizons/ExampleMod1.7.10/blob/main/gradle.properties")
-}
+    if (!project.hasProperty(propertyName)) {
+        throw new GradleException("This project requires a property \"" + propertyName + "\"! Please add it your \"gradle.properties\". You can find all properties and their description here: https://github.com/GTNewHorizons/ExampleMod1.7.10/blob/main/gradle.properties")
+    }
 }
 
 def getFile(String relativePath) {
-return new File(projectDir, relativePath)
+    return new File(projectDir, relativePath)
 }

--- a/build.gradle
+++ b/build.gradle
@@ -404,7 +404,7 @@ jar {
 }
 
 reobf {
-    if(usesMixins.toBoolean() && file(mixinSrg).exists()) {
+    if(usesMixins.toBoolean()) {
         addExtraSrgFile mixinSrg
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,6 +5,6 @@ plugins {
 apply plugin: 'com.diffplug.blowdryerSetup'
 
 blowdryerSetup {
-    //github('GTNewHorizons/ExampleMod1.7.10', 'tag', '0.1.4')
+    //github('GTNewHorizons/ExampleMod1.7.10', 'tag', '0.1.5')
     devLocal '.' // Use this when testing config updates locally
 }

--- a/settings.gradle.example
+++ b/settings.gradle.example
@@ -5,6 +5,6 @@ plugins {
 apply plugin: 'com.diffplug.blowdryerSetup'
 
 blowdryerSetup {
-    github('GTNewHorizons/ExampleMod1.7.10', 'tag', '0.1.4')
+    github('GTNewHorizons/ExampleMod1.7.10', 'tag', '0.1.5')
     //devLocal '.' // Use this when testing config updates locally
 }

--- a/src/main/resources/spotless.gradle
+++ b/src/main/resources/spotless.gradle
@@ -27,14 +27,4 @@ spotless {
         indentWithSpaces(4)
         endWithNewline()
     }
-    groovyGradle {
-        toggleOffOn()
-        // importOrder() disabled until someone can fix this
-        target '*.gradle'
-        greclipse('4.19.0') // last version supporting jvm 8
-
-        trimTrailingWhitespace()
-        indentWithSpaces(4)
-        endWithNewline()
-    }
 }


### PR DESCRIPTION
Revert #51 - While this was used to fix the compile issue with mixingasm, it caused trouble with hodgepodge build on CI - the first build would not properly reobf the mixins, however a second build (locally) would after the file was properly generated.  We'll need to investigate a fix that works with hodgepodge and mixingasm.

While I'm at it, remove dependency on jitpack, update to forge gradle 1.2.9, and stop applying spotless on build.gradle (it's not working properly on the functions later in the file)