### PR TITLE
Automatic GTNH Mixin Dependency for artifacts on CurseForge and Modrinth

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -693,6 +693,9 @@ if (modrinthProjectId.size() != 0 && System.getenv("MODRINTH_TOKEN") != null) {
             addModrinthDep(qual[0], qual[1], parts[1])
         }
     }
+    if (usesMixins.toBoolean()) {
+        addModrinthDep("required", "version", "gtnhmixins")
+    }
     tasks.modrinth.dependsOn(build)
     tasks.publish.dependsOn(tasks.modrinth)
 }
@@ -733,6 +736,9 @@ if (curseForgeProjectId.size() != 0 && System.getenv("CURSEFORGE_TOKEN") != null
             String[] parts = dep.split(":")
             addCurseForgeRelation(parts[0], parts[1])
         }
+    }
+    if (usesMixins.toBoolean()) {
+        addCurseForgeRelation("requiredDependency", "gtnhmixins")
     }
     tasks.curseforge.dependsOn(build)
     tasks.publish.dependsOn(tasks.curseforge)

--- a/gradle.properties
+++ b/gradle.properties
@@ -84,6 +84,7 @@ modrinthProjectId =
 #       type can be one of [project, version],
 #       and the name is the Modrinth project or version slug/id of the other mod.
 # Example: required-project:fplib;optional-project:gasstation;incompatible-project:gregtech
+# Note: GTNH Mixins is automatically set as a required dependency if usesMixins = true
 modrinthRelations =
 
 
@@ -96,8 +97,9 @@ curseForgeProjectId =
 # The project's relations on CurseForge. You can use this to refer to other projects on CurseForge.
 # Syntax: type1:name1;type2:name2;...
 # Where type can be one of [requiredDependency, embeddedLibrary, optionalDependency, tool, incompatible],
-#       and the name is the CurseForge project id of the other mod.
+#       and the name is the CurseForge project slug of the other mod.
 # Example: requiredDependency:railcraft;embeddedLibrary:cofhlib;incompatible:buildcraft
+# Note: GTNH Mixins is automatically set as a required dependency if usesMixins = true
 curseForgeRelations =
 
 


### PR DESCRIPTION
Automatically sets GTNH Mixins as a dependency for CurseForge and/or Modrinth artifacts if mixins are enabled