### PR TITLE
Fix shell gradle wrapper outdated bad practices

### DIFF
--- a/gradlew
+++ b/gradlew
@@ -27,23 +27,25 @@
 PRG="$0"
 # Need this for relative symlinks.
 while [ -h "$PRG" ] ; do
-    ls=`ls -ld "$PRG"`
-    link=`expr "$ls" : '.*-> \(.*\)$'`
+    ls=$(ls -ld "$PRG")
+    link=$(expr "$ls" : '.*-> \(.*\)$')
     if expr "$link" : '/.*' > /dev/null; then
         PRG="$link"
     else
-        PRG=`dirname "$PRG"`"/$link"
+        PRG="${PRG%/*}/$link"
     fi
 done
-SAVED="`pwd`"
-cd "`dirname \"$PRG\"`/" >/dev/null
-APP_HOME="`pwd -P`"
-cd "$SAVED" >/dev/null
+SAVED="$PWD"
+cd "${PRG%/*}/" >/dev/null || exit
+APP_HOME="$(pwd -P)"
+cd "$SAVED" >/dev/null || exit
 
 APP_NAME="Gradle"
-APP_BASE_NAME=`basename "$0"`
+# shellcheck disable=SC2034 # Used inside eval statement
+APP_BASE_NAME=${0##*/}
 
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+# shellcheck disable=SC2034 # Used inside eval statement
 DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
@@ -65,7 +67,7 @@ cygwin=false
 msys=false
 darwin=false
 nonstop=false
-case "`uname`" in
+case "$(uname)" in
   CYGWIN* )
     cygwin=true
     ;;
@@ -80,7 +82,7 @@ case "`uname`" in
     ;;
 esac
 
-CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
+CLASSPATH="$APP_HOME/gradle/wrapper/gradle-wrapper.jar"
 
 # Determine the Java command to use to start the JVM.
 if [ -n "$JAVA_HOME" ] ; then
@@ -105,14 +107,13 @@ location of your Java installation."
 fi
 
 # Increase the maximum file descriptors if we can.
-if [ "$cygwin" = "false" -a "$darwin" = "false" -a "$nonstop" = "false" ] ; then
-    MAX_FD_LIMIT=`ulimit -H -n`
-    if [ $? -eq 0 ] ; then
-        if [ "$MAX_FD" = "maximum" -o "$MAX_FD" = "max" ] ; then
+if [ "$cygwin" = "false" ] && [ "$darwin" = "false" ] && [ "$nonstop" = "false" ] ; then
+    # shellcheck disable=SC3045 # ulimit -H -n is widely supported
+    if MAX_FD_LIMIT=$(ulimit -H -n) ; then
+        if [ "$MAX_FD" = "maximum" ] || [ "$MAX_FD" = "max" ] ; then
             MAX_FD="$MAX_FD_LIMIT"
         fi
-        ulimit -n $MAX_FD
-        if [ $? -ne 0 ] ; then
+        if ! ulimit -n "$MAX_FD" ; then
             warn "Could not set maximum file descriptor limit: $MAX_FD"
         fi
     else
@@ -126,16 +127,15 @@ if $darwin; then
 fi
 
 # For Cygwin or MSYS, switch paths to Windows format before running java
-if [ "$cygwin" = "true" -o "$msys" = "true" ] ; then
-    APP_HOME=`cygpath --path --mixed "$APP_HOME"`
-    CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
-    JAVACMD=`cygpath --unix "$JAVACMD"`
+if [ "$cygwin" = "true" ] || [ "$msys" = "true" ] ; then
+    APP_HOME=$(cygpath --path --mixed "$APP_HOME")
+    CLASSPATH=$(cygpath --path --mixed "$CLASSPATH")
+    JAVACMD=$(cygpath --unix "$JAVACMD")
 
     # We build the pattern for arguments to be converted via cygpath
-    ROOTDIRSRAW=`find -L / -maxdepth 1 -mindepth 1 -type d 2>/dev/null`
     SEP=""
-    for dir in $ROOTDIRSRAW ; do
-        ROOTDIRS="$ROOTDIRS$SEP$dir"
+    for dir in /*/; do
+        ROOTDIRS="$ROOTDIRS$SEP${dir%?}"
         SEP="|"
     done
     OURCYGPATTERN="(^($ROOTDIRS))"
@@ -146,16 +146,17 @@ if [ "$cygwin" = "true" -o "$msys" = "true" ] ; then
     # Now convert the arguments - kludge to limit ourselves to /bin/sh
     i=0
     for arg in "$@" ; do
-        CHECK=`echo "$arg"|egrep -c "$OURCYGPATTERN" -`
-        CHECK2=`echo "$arg"|egrep -c "^-"`                                 ### Determine if an option
+        CHECK=$(echo "$arg"|grep -c -E "$OURCYGPATTERN" -)
+        CHECK2=$(echo "$arg"|grep -c -E "^-")                                 ### Determine if an option
 
-        if [ $CHECK -ne 0 ] && [ $CHECK2 -eq 0 ] ; then                    ### Added a condition
-            eval `echo args$i`=`cygpath --path --ignore --mixed "$arg"`
+        if [ "$CHECK" -ne 0 ] && [ "$CHECK2" -eq 0 ] ; then                    ### Added a condition
+            eval "args$i=\$(cygpath --path --ignore --mixed \"\$arg\")"
         else
-            eval `echo args$i`="\"$arg\""
+            eval "args$i=\"\$arg\""
         fi
         i=$((i+1))
     done
+    # shellcheck disable=SC2154 # Dynamic variable names
     case $i in
         (0) set -- ;;
         (1) set -- "$args0" ;;
@@ -175,14 +176,16 @@ save () {
     for i do printf %s\\n "$i" | sed "s/'/'\\\\''/g;1s/^/'/;\$s/\$/' \\\\/" ; done
     echo " "
 }
+
+# shellcheck disable=SC2034 # Used inside eval statement
 APP_ARGS=$(save "$@")
 
 # Collect all arguments for the java command, following the shell quoting and substitution rules
-eval set -- $DEFAULT_JVM_OPTS $JAVA_OPTS $GRADLE_OPTS "\"-Dorg.gradle.appname=$APP_BASE_NAME\"" -classpath "\"$CLASSPATH\"" org.gradle.wrapper.GradleWrapperMain "$APP_ARGS"
+eval "set -- $DEFAULT_JVM_OPTS $JAVA_OPTS $GRADLE_OPTS \"-Dorg.gradle.appname=$APP_BASE_NAME\" -classpath \"$CLASSPATH\" org.gradle.wrapper.GradleWrapperMain $APP_ARGS"
 
 # by default we should be in the correct project dir, but when run from Finder on Mac, the cwd is wrong
 if [ "$(uname)" = "Darwin" ] && [ "$HOME" = "$PWD" ]; then
-  cd "$(dirname "$0")"
+  cd "$(dirname "$0")" || exit
 fi
 
 exec "$JAVACMD" "$@"


### PR DESCRIPTION
Addresses all [ShellCheck](https://shellcheck.net)'s reported issues

ShellCheck report on original version:
```none

In gradlew line 30:
    ls=`ls -ld "$PRG"`
       ^-------------^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

Did you mean: 
    ls=$(ls -ld "$PRG")


In gradlew line 31:
    link=`expr "$ls" : '.*-> \(.*\)$'`
         ^---------------------------^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

Did you mean: 
    link=$(expr "$ls" : '.*-> \(.*\)$')


In gradlew line 35:
        PRG=`dirname "$PRG"`"/$link"
            ^--------------^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

Did you mean: 
        PRG=$(dirname "$PRG")"/$link"


In gradlew line 38:
SAVED="`pwd`"
       ^---^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

Did you mean: 
SAVED="$(pwd)"


In gradlew line 39:
cd "`dirname \"$PRG\"`/" >/dev/null
^-- SC2164 (warning): Use 'cd ... || exit' or 'cd ... || return' in case cd fails.
    ^----------------^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

Did you mean: 
cd "$(dirname \"$PRG\")/" >/dev/null || exit


In gradlew line 40:
APP_HOME="`pwd -P`"
          ^------^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

Did you mean: 
APP_HOME="$(pwd -P)"


In gradlew line 41:
cd "$SAVED" >/dev/null
^--------------------^ SC2164 (warning): Use 'cd ... || exit' or 'cd ... || return' in case cd fails.

Did you mean: 
cd "$SAVED" >/dev/null || exit


In gradlew line 44:
APP_BASE_NAME=`basename "$0"`
              ^-------------^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

Did you mean: 
APP_BASE_NAME=$(basename "$0")


In gradlew line 68:
case "`uname`" in
      ^-----^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

Did you mean: 
case "$(uname)" in


In gradlew line 108:
if [ "$cygwin" = "false" -a "$darwin" = "false" -a "$nonstop" = "false" ] ; then
                         ^-- SC2166 (warning): Prefer [ p ] && [ q ] as [ p -a q ] is not well defined.
                                                ^-- SC2166 (warning): Prefer [ p ] && [ q ] as [ p -a q ] is not well defined.


In gradlew line 109:
    MAX_FD_LIMIT=`ulimit -H -n`
                 ^------------^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.
                         ^-- SC3045 (warning): In POSIX sh, ulimit -H is undefined.

Did you mean: 
    MAX_FD_LIMIT=$(ulimit -H -n)


In gradlew line 110:
    if [ $? -eq 0 ] ; then
         ^-- SC2181 (style): Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.


In gradlew line 111:
        if [ "$MAX_FD" = "maximum" -o "$MAX_FD" = "max" ] ; then
                                   ^-- SC2166 (warning): Prefer [ p ] || [ q ] as [ p -o q ] is not well defined.


In gradlew line 114:
        ulimit -n $MAX_FD
               ^-- SC3045 (warning): In POSIX sh, ulimit -n is undefined.
                  ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
        ulimit -n "$MAX_FD"


In gradlew line 115:
        if [ $? -ne 0 ] ; then
             ^-- SC2181 (style): Check exit code directly with e.g. 'if ! mycmd;', not indirectly with $?.


In gradlew line 129:
if [ "$cygwin" = "true" -o "$msys" = "true" ] ; then
                        ^-- SC2166 (warning): Prefer [ p ] || [ q ] as [ p -o q ] is not well defined.


In gradlew line 130:
    APP_HOME=`cygpath --path --mixed "$APP_HOME"`
             ^-- SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

Did you mean: 
    APP_HOME=$(cygpath --path --mixed "$APP_HOME")


In gradlew line 131:
    CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
              ^-- SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

Did you mean: 
    CLASSPATH=$(cygpath --path --mixed "$CLASSPATH")


In gradlew line 132:
    JAVACMD=`cygpath --unix "$JAVACMD"`
            ^-------------------------^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

Did you mean: 
    JAVACMD=$(cygpath --unix "$JAVACMD")


In gradlew line 135:
    ROOTDIRSRAW=`find -L / -maxdepth 1 -mindepth 1 -type d 2>/dev/null`
                ^-- SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

Did you mean: 
    ROOTDIRSRAW=$(find -L / -maxdepth 1 -mindepth 1 -type d 2>/dev/null)


In gradlew line 149:
        CHECK=`echo "$arg"|egrep -c "$OURCYGPATTERN" -`
              ^-- SC2006 (style): Use $(...) notation instead of legacy backticks `...`.
                           ^---^ SC2196 (info): egrep is non-standard and deprecated. Use grep -E instead.

Did you mean: 
        CHECK=$(echo "$arg"|egrep -c "$OURCYGPATTERN" -)


In gradlew line 150:
        CHECK2=`echo "$arg"|egrep -c "^-"`                                 ### Determine if an option
               ^-------------------------^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.
                            ^---^ SC2196 (info): egrep is non-standard and deprecated. Use grep -E instead.

Did you mean: 
        CHECK2=$(echo "$arg"|egrep -c "^-")                                 ### Determine if an option


In gradlew line 152:
        if [ $CHECK -ne 0 ] && [ $CHECK2 -eq 0 ] ; then                    ### Added a condition
             ^----^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                 ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
        if [ "$CHECK" -ne 0 ] && [ "$CHECK2" -eq 0 ] ; then                    ### Added a condition


In gradlew line 153:
            eval `echo args$i`=`cygpath --path --ignore --mixed "$arg"`
                 ^-----------^ SC2046 (warning): Quote this to prevent word splitting.
                 ^-----------^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.
                 ^-----------^ SC2116 (style): Useless echo? Instead of 'cmd $(echo foo)', just use 'cmd foo'.
                               ^-- SC2046 (warning): Quote this to prevent word splitting.
                               ^-- SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

Did you mean: 
            eval $(echo args$i)=$(cygpath --path --ignore --mixed "$arg")


In gradlew line 155:
            eval `echo args$i`="\"$arg\""
                 ^-----------^ SC2046 (warning): Quote this to prevent word splitting.
                 ^-----------^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.
                 ^-----------^ SC2116 (style): Useless echo? Instead of 'cmd $(echo foo)', just use 'cmd foo'.

Did you mean: 
            eval $(echo args$i)="\"$arg\""


In gradlew line 161:
        (1) set -- "$args0" ;;
                    ^----^ SC2154 (warning): args0 is referenced but not assigned.


In gradlew line 162:
        (2) set -- "$args0" "$args1" ;;
                             ^----^ SC2154 (warning): args1 is referenced but not assigned.


In gradlew line 163:
        (3) set -- "$args0" "$args1" "$args2" ;;
                                      ^----^ SC2154 (warning): args2 is referenced but not assigned.


In gradlew line 164:
        (4) set -- "$args0" "$args1" "$args2" "$args3" ;;
                                               ^----^ SC2154 (warning): args3 is referenced but not assigned.


In gradlew line 165:
        (5) set -- "$args0" "$args1" "$args2" "$args3" "$args4" ;;
                                                        ^----^ SC2154 (warning): args4 is referenced but not assigned.


In gradlew line 166:
        (6) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" ;;
                                                                 ^----^ SC2154 (warning): args5 is referenced but not assigned.


In gradlew line 167:
        (7) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" ;;
                                                                          ^----^ SC2154 (warning): args6 is referenced but not assigned.


In gradlew line 168:
        (8) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" ;;
                                                                                   ^----^ SC2154 (warning): args7 is referenced but not assigned.


In gradlew line 169:
        (9) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" "$args8" ;;
                                                                                            ^----^ SC2154 (warning): args8 is referenced but not assigned.


In gradlew line 181:
eval set -- $DEFAULT_JVM_OPTS $JAVA_OPTS $GRADLE_OPTS "\"-Dorg.gradle.appname=$APP_BASE_NAME\"" -classpath "\"$CLASSPATH\"" org.gradle.wrapper.GradleWrapperMain "$APP_ARGS"
            ^---------------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                              ^--------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                         ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
eval set -- "$DEFAULT_JVM_OPTS" "$JAVA_OPTS" "$GRADLE_OPTS" "\"-Dorg.gradle.appname=$APP_BASE_NAME\"" -classpath "\"$CLASSPATH\"" org.gradle.wrapper.GradleWrapperMain "$APP_ARGS"


In gradlew line 185:
  cd "$(dirname "$0")"
  ^------------------^ SC2164 (warning): Use 'cd ... || exit' or 'cd ... || return' in case cd fails.

Did you mean: 
  cd "$(dirname "$0")" || exit

For more information:
  https://www.shellcheck.net/wiki/SC2046 -- Quote this to prevent word splitt...
  https://www.shellcheck.net/wiki/SC2154 -- args0 is referenced but not assig...
  https://www.shellcheck.net/wiki/SC2164 -- Use 'cd ... || exit' or 'cd ... |...
```