### PR TITLE
Add FernFlower for Mixin Debugging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -331,7 +331,7 @@ repositories {
             url = "http://jenkins.usrv.eu:8081/nexus/content/groups/public/"
         }
         maven {
-            maven = "Fabric Maven"
+            name = "Fabric Maven"
             url = "https://maven.fabricmc.net/"
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -330,6 +330,10 @@ repositories {
             name = "GTNH Maven"
             url = "http://jenkins.usrv.eu:8081/nexus/content/groups/public/"
         }
+        maven {
+            maven = "Fabric Maven"
+            url = "https://maven.fabricmc.net/"
+        }
     }
 }
 
@@ -339,6 +343,7 @@ dependencies {
         annotationProcessor('com.google.guava:guava:24.1.1-jre')
         annotationProcessor('com.google.code.gson:gson:2.8.6')
         annotationProcessor('com.gtnewhorizon:gtnhmixins:2.1.1:processor')
+        runtimeOnly('org.jetbrains:intellij-fernflower:1.2.1.16')
     }
     if (usesMixins.toBoolean() || forceEnableMixins.toBoolean()) {
         compile('com.gtnewhorizon:gtnhmixins:2.1.1')

--- a/build.gradle
+++ b/build.gradle
@@ -330,9 +330,11 @@ repositories {
             name = "GTNH Maven"
             url = "http://jenkins.usrv.eu:8081/nexus/content/groups/public/"
         }
-        maven {
-            name = "Fabric Maven"
-            url = "https://maven.fabricmc.net/"
+        if (usesMixinDebug.toBoolean()) {
+            maven {
+                name = "Fabric Maven"
+                url = "https://maven.fabricmc.net/"
+            }
         }
     }
 }
@@ -343,7 +345,9 @@ dependencies {
         annotationProcessor('com.google.guava:guava:24.1.1-jre')
         annotationProcessor('com.google.code.gson:gson:2.8.6')
         annotationProcessor('com.gtnewhorizon:gtnhmixins:2.1.1:processor')
-        runtimeOnly('org.jetbrains:intellij-fernflower:1.2.1.16')
+        if (usesMixinDebug.toBoolean()) {
+            runtimeOnly('org.jetbrains:intellij-fernflower:1.2.1.16')
+        }
     }
     if (usesMixins.toBoolean() || forceEnableMixins.toBoolean()) {
         compile('com.gtnewhorizon:gtnhmixins:2.1.1')


### PR DESCRIPTION
Tranformed classes will be decompiled and copied to `./run/.mixin.out/java`.

This is the newest version I could find (from September 2020).