### PR TITLE
Overwrite current ASM with a custom version.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ buildscript {
             url 'https://maven.minecraftforge.net'
         }
         maven {
-            // GTNH ForgeGradle Fork
+            // GTNH ForgeGradle and ASM Fork
             name = "GTNH Maven"
             url = "http://jenkins.usrv.eu:8081/nexus/content/groups/public/"
         }

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,8 @@ buildscript {
         }
     }
     dependencies {
+        //Overwrite the current ASM version to fix shading newer than java 8 applicatations.
+        classpath 'org.ow2.asm:asm-debug-all-custom:5.0.3'  
         classpath 'net.minecraftforge.gradle:ForgeGradle:1.2.11'
     }
 }


### PR DESCRIPTION
Fixes shading by using a custom version of ASM 5.0.3 that recognizes up to java 20.