### PR TITLE
Allow Token Replacement in multiple Files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -280,7 +280,9 @@ minecraft {
     runDir = 'run'
 
     if (replaceGradleTokenInFile) {
-        replaceIn replaceGradleTokenInFile
+        for (f in replaceGradleTokenInFile.split(',')) {
+            replaceIn f
+        }
         if (gradleTokenModId) {
             replace gradleTokenModId, modId
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,6 +29,7 @@ remoteMappings = https://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/con
 developmentEnvironmentUserName = Developer
 
 # Define a source file of your project with:
+# Multiple source files can be defined here by providing a comma-seperated list: Class1.java,Class2.java,Class3.java
 # public static final String VERSION = "GRADLETOKEN_VERSION";
 # The string's content will be replaced with your mod's version when compiled. You should use this to specify your mod's
 # version in @Mod([...], version = VERSION, [...])


### PR DESCRIPTION
Example usecase: directly replacing a version token in an `@API` annotated `package-info.java` file