### PR TITLE
Add an option to not minimize shadowed dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1673027205
+//version: 1674294951
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -144,6 +144,7 @@ propertyDefaultIfUnset("modrinthProjectId", "")
 propertyDefaultIfUnset("modrinthRelations", "")
 propertyDefaultIfUnset("curseForgeProjectId", "")
 propertyDefaultIfUnset("curseForgeRelations", "")
+propertyDefaultIfUnset("minimizeShadowedDependencies", true)
 
 String javaSourceDir = "src/main/java/"
 String scalaSourceDir = "src/main/scala/"
@@ -411,7 +412,9 @@ shadowJar {
         attributes(getManifestAttributes())
     }
 
-    minimize()  // This will only allow shading for actually used classes
+    if (minimizeShadowedDependencies.toBoolean()) {
+        minimize()  // This will only allow shading for actually used classes
+    }
     configurations = [
         project.configurations.shadowImplementation,
         project.configurations.shadowCompile
@@ -554,7 +557,9 @@ task shadowDevJar(type: ShadowJar) {
         attributes(getManifestAttributes())
     }
 
-    minimize()  // This will only allow shading for actually used classes
+    if (minimizeShadowedDependencies.toBoolean()) {
+        minimize()  // This will only allow shading for actually used classes
+    }
     configurations = [
         project.configurations.shadowImplementation,
         project.configurations.shadowCompile

--- a/gradle.properties
+++ b/gradle.properties
@@ -71,6 +71,9 @@ forceEnableMixins = false
 # If enabled, you may use 'shadowCompile' for dependencies. They will be integrated in your jar. It is your
 # responsibility check the licence and request permission for distribution, if required.
 usesShadowedDependencies = false
+# If disabled, won't remove unused classes from shaded dependencies. Some libraries use reflection to access
+# their own classes, making the minimization unreliable.
+minimizeShadowedDependencies = true
 
 
 # Publishing to modrinth requires you to set the MODRINTH_TOKEN environment variable to your current modrinth API token.


### PR DESCRIPTION
Some libraries use reflection to access their own classes, making the minimization unreliable.