### PR TITLE
Allow disabling update check via system property

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -803,7 +803,7 @@ task updateBuildScript {
     }
 }
 
-if (!project.getGradle().startParameter.isOffline() && !System.getenv('DISABLE_BUILDSCRIPT_UPDATE_CHECK') && isNewBuildScriptVersionAvailable(projectDir.toString())) {
+if (!project.getGradle().startParameter.isOffline() && !Boolean.getBoolean('DISABLE_BUILDSCRIPT_UPDATE_CHECK') && isNewBuildScriptVersionAvailable(projectDir.toString())) {
     if (autoUpdateBuildScript.toBoolean()) {
         performBuildScriptUpdate(projectDir.toString())
     } else {

--- a/build.gradle
+++ b/build.gradle
@@ -803,7 +803,7 @@ task updateBuildScript {
     }
 }
 
-if (!project.getGradle().startParameter.isOffline() && isNewBuildScriptVersionAvailable(projectDir.toString())) {
+if (!project.getGradle().startParameter.isOffline() && !System.getenv('DISABLE_BUILDSCRIPT_UPDATE_CHECK') && isNewBuildScriptVersionAvailable(projectDir.toString())) {
     if (autoUpdateBuildScript.toBoolean()) {
         performBuildScriptUpdate(projectDir.toString())
     } else {


### PR DESCRIPTION
This speeds up `gradlew spotlessApply` considerably when you have a poor wifi, without the hassle of adding `--offline` everywhere.