### PR TITLE
Add Java 17 and HotSwapAgent-enabled run configurations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1675624371
+//version: 1675784701
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -10,10 +10,13 @@ import com.diffplug.blowdryer.Blowdryer
 import com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocation
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import com.gtnewhorizons.retrofuturagradle.mcp.ReobfuscatedJar
+import com.gtnewhorizons.retrofuturagradle.minecraft.RunMinecraftTask
 import com.matthewprenger.cursegradle.CurseArtifact
 import com.matthewprenger.cursegradle.CurseRelation
 import com.modrinth.minotaur.dependencies.ModDependency
 import com.modrinth.minotaur.dependencies.VersionDependency
+import cpw.mods.fml.relauncher.Side
+import org.gradle.api.tasks.options.Option;
 import org.gradle.internal.logging.text.StyledTextOutput.Style
 import org.gradle.internal.logging.text.StyledTextOutputFactory
 import org.jetbrains.gradle.ext.*
@@ -23,6 +26,7 @@ import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
+import javax.inject.Inject
 
 buildscript {
     repositories {
@@ -66,7 +70,7 @@ plugins {
     id 'com.diffplug.spotless' version '6.7.2' apply false
     id 'com.modrinth.minotaur' version '2.+' apply false
     id 'com.matthewprenger.cursegradle' version '1.4.0' apply false
-    id 'com.gtnewhorizons.retrofuturagradle' version '1.1.4'
+    id 'com.gtnewhorizons.retrofuturagradle' version '1.1.5'
 }
 boolean settingsupdated = verifySettingsGradle()
 settingsupdated = verifyGitAttributes() || settingsupdated
@@ -186,11 +190,21 @@ configurations {
 }
 
 if (enableModernJavaSyntax.toBoolean()) {
+    repositories {
+        mavenCentral {
+            mavenContent {
+                includeGroup("me.eigenraven.java8unsupported")
+            }
+        }
+    }
+
     dependencies {
         annotationProcessor 'com.github.bsideup.jabel:jabel-javac-plugin:1.0.0'
         compileOnly('com.github.bsideup.jabel:jabel-javac-plugin:1.0.0') {
             transitive = false // We only care about the 1 annotation class
         }
+        // Allow using jdk.unsupported classes like sun.misc.Unsafe in the compiled code, working around JDK-8206937.
+        patchedMinecraft('me.eigenraven.java8unsupported:java-8-unsupported-shim:1.0.0')
     }
 
     tasks.withType(JavaCompile).configureEach {
@@ -637,6 +651,138 @@ tasks.named("processResources", ProcessResources).configure {
     }
 }
 
+ext.java17Toolchain = (JavaToolchainSpec spec) -> {
+    spec.languageVersion.set(JavaLanguageVersion.of(17))
+    spec.vendor.set(JvmVendorSpec.matching("jetbrains"))
+}
+
+ext.java17DependenciesCfg = configurations.create("java17Dependencies")
+ext.java17PatchDependenciesCfg = configurations.create("java17PatchDependencies")
+
+dependencies {
+    def lwjgl3ifyVersion = '1.1.21'
+    def asmVersion = '9.4'
+    if (modId != 'lwjgl3ify') {
+        java17Dependencies("com.github.GTNewHorizons:lwjgl3ify:${lwjgl3ifyVersion}")
+    }
+    if (modId != 'hodgepodge') {
+        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.0.31')
+    }
+
+    java17PatchDependencies('net.minecraft:launchwrapper:1.15') {transitive = false}
+    java17PatchDependencies("org.ow2.asm:asm:${asmVersion}")
+    java17PatchDependencies("org.ow2.asm:asm-commons:${asmVersion}")
+    java17PatchDependencies("org.ow2.asm:asm-tree:${asmVersion}")
+    java17PatchDependencies("org.ow2.asm:asm-analysis:${asmVersion}")
+    java17PatchDependencies("org.ow2.asm:asm-util:${asmVersion}")
+    java17PatchDependencies('org.ow2.asm:asm-deprecated:7.1')
+    java17PatchDependencies("org.apache.commons:commons-lang3:3.12.0")
+    java17PatchDependencies("com.github.GTNewHorizons:lwjgl3ify:${lwjgl3ifyVersion}:forgePatches")
+}
+
+ext.java17JvmArgs = [
+    // Java 9+ support
+    "--illegal-access=warn",
+    "-Dfile.encoding=UTF-8",
+    "-Djava.security.manager=allow",
+    "--add-opens", "java.base/jdk.internal.loader=ALL-UNNAMED",
+    "--add-opens", "java.base/java.net=ALL-UNNAMED",
+    "--add-opens", "java.base/java.nio=ALL-UNNAMED",
+    "--add-opens", "java.base/java.io=ALL-UNNAMED",
+    "--add-opens", "java.base/java.lang=ALL-UNNAMED",
+    "--add-opens", "java.base/java.lang.reflect=ALL-UNNAMED",
+    "--add-opens", "java.base/java.text=ALL-UNNAMED",
+    "--add-opens", "java.base/java.util=ALL-UNNAMED",
+    "--add-opens", "java.base/jdk.internal.reflect=ALL-UNNAMED",
+    "--add-opens", "java.base/sun.nio.ch=ALL-UNNAMED",
+    "--add-opens", "java.desktop/sun.awt.image=ALL-UNNAMED",
+    "--add-modules", "jdk.dynalink",
+    "--add-opens", "jdk.dynalink/jdk.dynalink.beans=ALL-UNNAMED",
+    "--add-modules", "java.sql.rowset",
+    "--add-opens", "java.sql.rowset/javax.sql.rowset.serial=ALL-UNNAMED"
+]
+
+ext.hotswapJvmArgs = [
+    // DCEVM advanced hot reload
+    "-XX:+AllowEnhancedClassRedefinition",
+    "-XX:HotswapAgent=fatjar"
+]
+
+ext.setupHotswapAgentTask = tasks.register("setupHotswapAgent") {
+    group = "GTNH Buildscript"
+    description = "Installs a recent version of HotSwapAgent into the Java 17 JetBrains runtime directory"
+    def hsaUrl = 'https://github.com/HotswapProjects/HotswapAgent/releases/download/1.4.2-SNAPSHOT/hotswap-agent-1.4.2-SNAPSHOT.jar'
+    def targetFolderProvider = javaToolchains.launcherFor(java17Toolchain).map {it.metadata.installationPath.dir("lib/hotswap")}
+    def targetFilename = "hotswap-agent.jar"
+    onlyIf {
+        !targetFolderProvider.get().file(targetFilename).asFile.exists()
+    }
+    doLast {
+        def targetFolder = targetFolderProvider.get()
+        targetFolder.asFile.mkdirs()
+        download.run {
+            src hsaUrl
+            dest targetFolder.file(targetFilename).asFile
+            overwrite false
+            tempAndMove true
+        }
+    }
+}
+
+public abstract class RunHotswappableMinecraftTask extends RunMinecraftTask {
+    // IntelliJ doesn't seem to allow commandline arguments so we also support an env variable
+    private boolean enableHotswap = Boolean.valueOf(System.getenv("HOTSWAP"));
+
+    @Input
+    public boolean getEnableHotswap() { return enableHotswap }
+    @Option(option = "hotswap", description = "Enables HotSwapAgent for enhanced class reloading under a debugger")
+    public boolean setEnableHotswap(boolean enable) { enableHotswap = enable }
+
+    @Inject
+    public RunHotswappableMinecraftTask(Side side, String superTask) {
+        super(side)
+
+        this.lwjglVersion = 3
+        this.javaLauncher = project.javaToolchains.launcherFor(project.java17Toolchain)
+        this.extraJvmArgs.addAll(project.java17JvmArgs)
+        this.extraJvmArgs.addAll(project.provider(() -> enableHotswap ? project.hotswapJvmArgs : []))
+
+        this.classpath(project.java17PatchDependenciesCfg)
+        if (side == Side.CLIENT) {
+            this.classpath(project.minecraftTasks.lwjgl3Configuration)
+        }
+        // Use a raw provider instead of map to not create a dependency on the task
+        this.classpath(project.provider(() -> project.tasks.named(superTask, RunMinecraftTask).get().classpath))
+        this.classpath.filter { file ->
+            !file.path.contains("2.9.4-nightly-20150209") // Remove lwjgl2
+        }
+        this.classpath(project.java17DependenciesCfg)
+
+        if (!(project.usesMixins.toBoolean() || project.forceEnableMixins.toBoolean())) {
+            this.extraArgs.addAll("--tweakClass", "org.spongepowered.asm.launch.MixinTweaker")
+        }
+    }
+}
+
+def runClient17Task = tasks.register("runClient17", RunHotswappableMinecraftTask, Side.CLIENT, "runClient")
+runClient17Task.configure {
+    setup(project)
+    group = "Modded Minecraft"
+    description = "Runs the modded client using Java 17, lwjgl3ify and Hodgepodge"
+    dependsOn(setupHotswapAgentTask, mcpTasks.launcherSources.classesTaskName, minecraftTasks.taskDownloadVanillaAssets, mcpTasks.taskPackagePatchedMc, 'jar')
+    mainClass = "GradleStart"
+}
+
+def runServer17Task = tasks.register("runServer17", RunHotswappableMinecraftTask, Side.SERVER, "runServer")
+runServer17Task.configure {
+    setup(project)
+    group = "Modded Minecraft"
+    description = "Runs the modded server using Java 17, lwjgl3ify and Hodgepodge"
+    dependsOn(setupHotswapAgentTask, mcpTasks.launcherSources.classesTaskName, minecraftTasks.taskDownloadVanillaAssets, mcpTasks.taskPackagePatchedMc, 'jar')
+    mainClass = "GradleStartServer"
+    extraArgs.add("nogui")
+}
+
 def getManifestAttributes() {
     def manifestAttributes = [:]
     if (!containsMixinsAndOrCoreModOnly.toBoolean() && (usesMixins.toBoolean() || coreModClass)) {
@@ -706,7 +852,7 @@ if (usesShadowedDependencies.toBoolean()) {
     javaComponent.withVariantsFromConfiguration(configurations.shadowRuntimeElements) {
         skip()
     }
-    for (runTask in ["runClient", "runServer"]) {
+    for (runTask in ["runClient", "runServer", "runClient17", "runServer17"]) {
         tasks.named(runTask).configure {
             dependsOn("shadowJar")
         }
@@ -754,6 +900,20 @@ idea {
                 }
                 "2. Run Server"(Gradle) {
                     taskNames = ["runServer"]
+                }
+                "1a. Run Client (Java 17)"(Gradle) {
+                    taskNames = ["runClient17"]
+                }
+                "2a. Run Server (Java 17)"(Gradle) {
+                    taskNames = ["runServer17"]
+                }
+                "1b. Run Client (Java 17, Hotswap)"(Gradle) {
+                    taskNames = ["runClient17"]
+                    envs = ["HOTSWAP": "true"]
+                }
+                "2b. Run Server (Java 17, Hotswap)"(Gradle) {
+                    taskNames = ["runServer17"]
+                    envs = ["HOTSWAP": "true"]
                 }
                 "3. Run Obfuscated Client"(Gradle) {
                     taskNames = ["runObfClient"]


### PR DESCRIPTION
This PR adds `runClient17` and `runServer17` gradle tasks which use the DCEVM-enabled JetBrains runtime (<https://github.com/JetBrains/JetBrainsRuntime/>), lwjgl3ify and Hodgepodge to run mods in a Java 17 environment. HotSwapAgent can be optionally enabled by specifying `--hotswap` for improved hot swapping capabilities (adding/removing members and functions for example). Matching IntelliJ run configurations are also added.

To use the hotswap agent in intellij, make sure that build&run is delegated to Gradle in gradle settings, and that you run the correct configuration via the debugger.

There is a bug with gradle toolchain autoprovisioning right now, which prefers the `fastdebug` build of JBR instad of the regular one. It makes the game run a lot slower than usual, but can be fixed by downloading the regular runtime package, finding where gradle installed it (for me it was at `~/.gradle/jdks/jetbrains_s_r_o_-17-amd64-linux/jbrsdk-17.0.6-linux-x64-b802.1/`) and replacing the files there with the regular version. Make sure to keep the `provisioned.ok` file for gradle autodetection to work.