### PR TITLE
Stop ignoring mixins.*.(late|early).json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ whitelist.json
 *.iml
 *.ipr
 *.iws
-src/main/resources/mixins.*.json
+src/main/resources/mixins.*([!.]).json
 *.bat
 *.DS_Store
 !gradlew.bat


### PR DESCRIPTION
Stop ignoring mixins.*.(late|early).json

Fixes #131 

<img width="513" alt="image" src="https://user-images.githubusercontent.com/1894689/220222997-bc4e5eae-bc39-4276-8bda-54d93cfb7e56.png">
