### PR TITLE
Dependency handling tweaks and documentation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ plugins {
     id 'com.diffplug.spotless' version '6.7.2' apply false
     id 'com.modrinth.minotaur' version '2.+' apply false
     id 'com.matthewprenger.cursegradle' version '1.4.0' apply false
-    id 'com.gtnewhorizons.retrofuturagradle' version '1.2.1'
+    id 'com.gtnewhorizons.retrofuturagradle' version '1.2.2'
 }
 boolean settingsupdated = verifySettingsGradle()
 settingsupdated = verifyGitAttributes() || settingsupdated

--- a/build.gradle
+++ b/build.gradle
@@ -685,8 +685,13 @@ ext.java17Toolchain = (JavaToolchainSpec spec) -> {
     spec.vendor.set(JvmVendorSpec.matching("jetbrains"))
 }
 
-ext.java17DependenciesCfg = configurations.create("java17Dependencies")
-ext.java17PatchDependenciesCfg = configurations.create("java17PatchDependencies")
+ext.java17DependenciesCfg = configurations.create("java17Dependencies") {
+    extendsFrom(configurations.getByName("runtimeClasspath")) // Ensure consistent transitive dependency resolution
+    canBeConsumed = false
+}
+ext.java17PatchDependenciesCfg = configurations.create("java17PatchDependencies") {
+    canBeConsumed = false
+}
 
 dependencies {
     def lwjgl3ifyVersion = '1.1.28'
@@ -706,7 +711,7 @@ dependencies {
     java17PatchDependencies("org.ow2.asm:asm-util:${asmVersion}")
     java17PatchDependencies('org.ow2.asm:asm-deprecated:7.1')
     java17PatchDependencies("org.apache.commons:commons-lang3:3.12.0")
-    java17PatchDependencies("com.github.GTNewHorizons:lwjgl3ify:${lwjgl3ifyVersion}:forgePatches")
+    java17PatchDependencies("com.github.GTNewHorizons:lwjgl3ify:${lwjgl3ifyVersion}:forgePatches") {transitive = false}
 }
 
 ext.java17JvmArgs = [

--- a/build.gradle
+++ b/build.gradle
@@ -466,8 +466,9 @@ repositories.configureEach { repo ->
 apply from: 'repositories.gradle'
 
 configurations {
+    runtimeClasspath.extendsFrom(runtimeOnlyNonPublishable)
+    testRuntimeClasspath.extendsFrom(runtimeOnlyNonPublishable)
     for (config in [compileClasspath, runtimeClasspath, testCompileClasspath, testRuntimeClasspath]) {
-        config.extendsFrom(runtimeOnlyNonPublishable)
         if (usesShadowedDependencies.toBoolean()) {
             config.extendsFrom(shadowImplementation)
             // TODO: remove Compile after all uses are refactored to Implementation

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -6,6 +6,10 @@
  *       Available at runtime but not compiletime for mods depending on this mod
  *  - compileOnly("g:n:v:c"): if the mod you're building doesn't need this dependency during runtime at all, e.g. for optional mods
  *       Not available at all for mods depending on this mod, only visible at compiletime for this mod
+ *  - compileOnlyApi("g:n:v:c"): like compileOnly, but also visible at compiletime for mods depending on this mod
+ *       Available at compiletime but not runtime for mods depending on this mod
+ *  - runtimeOnlyNonPublishable("g:n:v:c"): if you want to include a mod in this mod's runClient/runServer runs, but not publish it as a dependency
+ *       Not available at all for mods depending on this mod, only visible at runtime for this mod
  *  - runtimeOnly("g:n:v:c"): if you don't need this at compile time, but want it to be present at runtime
  *       Available at runtime for mods depending on this mod
  *  - annotationProcessor("g:n:v:c"): mostly for java compiler plugins, if you know you need this, use it, otherwise don't worry
@@ -19,8 +23,10 @@
  * You can exclude transitive dependencies (dependencies of the chosen dependency) by appending { transitive = false } if needed,
  * but use this sparingly as it can break using your mod as another mod's dependency if you're not careful.
  *
- * For more details, see https://docs.gradle.org/7.6/userguide/java_library_plugin.html#sec:java_library_configurations_graph
+ * Gradle names for some of the configuration can be misleading, compileOnlyApi and runtimeOnly both get published as dependencies in Maven, but compileOnly does not.
+ * The buildscript adds runtimeOnlyNonPublishable to also have a runtime dependency that's not published.
+ *
+ * For more details, see https://docs.gradle.org/8.0.1/userguide/java_library_plugin.html#sec:java_library_configurations_graph
  */
 dependencies {
-
 }


### PR DESCRIPTION
 - Fix duplicate mods crash in run17 tasks when a different version of gtnhmixins/hodgepodge is present on the classpath
 - Fix and document runtimeOnlyNonPublishable as a configuration for runtime-only dependencies that don't get published as transitive
 - Document compileOnlyApi from Gradle's default configurations