### PR TITLE
Switch to UniMixins

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -513,14 +513,6 @@ repositories {
         url = "http://jenkins.usrv.eu:8081/nexus/content/groups/public/"
         allowInsecureProtocol = true
     }
-    if (usesMixins.toBoolean() || forceEnableMixins.toBoolean()) {
-        if (usesMixinDebug.toBoolean()) {
-            maven {
-                name = "Fabric Maven"
-                url = "https://maven.fabricmc.net/"
-            }
-        }
-    }
     maven {
         name 'sonatype'
         url 'https://oss.sonatype.org/content/repositories/snapshots/'
@@ -559,26 +551,42 @@ repositories {
     }
 }
 
+def mixinProviderGroup = "io.github.legacymoddingmc"
+def mixinProviderModule = "unimixins"
+def mixinProviderVersion = "0.1.5"
+def mixinProviderSpec = "${mixinProviderGroup}:${mixinProviderModule}:${mixinProviderVersion}"
+
 dependencies {
     if (usesMixins.toBoolean()) {
         annotationProcessor('org.ow2.asm:asm-debug-all:5.0.3')
         annotationProcessor('com.google.guava:guava:24.1.1-jre')
         annotationProcessor('com.google.code.gson:gson:2.8.6')
-        annotationProcessor('com.gtnewhorizon:gtnhmixins:2.1.13:processor')
+        annotationProcessor(mixinProviderSpec)
         if (usesMixinDebug.toBoolean()) {
             runtimeOnlyNonPublishable('org.jetbrains:intellij-fernflower:1.2.1.16')
         }
     }
     if (usesMixins.toBoolean() || forceEnableMixins.toBoolean()) {
-        implementation('com.gtnewhorizon:gtnhmixins:2.1.13')
+        implementation(mixinProviderSpec)
     }
 }
 
 pluginManager.withPlugin('org.jetbrains.kotlin.kapt') {
     if (usesMixins.toBoolean()) {
         dependencies {
-            kapt('com.gtnewhorizon:gtnhmixins:2.1.13:processor')
+            kapt(mixinProviderSpec)
         }
+    }
+}
+
+// Replace old mixin mods with unimixins
+// https://docs.gradle.org/8.0.2/userguide/resolution_rules.html#sec:substitution_with_classifier
+configurations.all {
+    resolutionStrategy.dependencySubstitution {
+        substitute module('com.gtnewhorizon:gtnhmixins') using module(mixinProviderSpec) withoutClassifier() because("Unimixins replaces other mixin mods")
+        substitute module('com.github.GTNewHorizons:Mixingasm') using module(mixinProviderSpec) withoutClassifier() because("Unimixins replaces other mixin mods")
+        substitute module('com.github.GTNewHorizons:SpongePoweredMixin') using module(mixinProviderSpec) withoutClassifier() because("Unimixins replaces other mixin mods")
+        substitute module('com.github.GTNewHorizons:SpongeMixins') using module(mixinProviderSpec) withoutClassifier() because("Unimixins replaces other mixin mods")
     }
 }
 
@@ -1125,7 +1133,7 @@ if (modrinthProjectId.size() != 0 && System.getenv("MODRINTH_TOKEN") != null) {
         }
     }
     if (usesMixins.toBoolean()) {
-        addModrinthDep("required", "project", "gtnhmixins")
+        addModrinthDep("required", "project", "unimixins")
     }
     tasks.modrinth.dependsOn(build)
     tasks.publish.dependsOn(tasks.modrinth)
@@ -1169,7 +1177,7 @@ if (curseForgeProjectId.size() != 0 && System.getenv("CURSEFORGE_TOKEN") != null
         }
     }
     if (usesMixins.toBoolean()) {
-        addCurseForgeRelation("requiredDependency", "gtnhmixins")
+        addCurseForgeRelation("requiredDependency", "unimixins")
     }
     tasks.curseforge.dependsOn(build)
     tasks.publish.dependsOn(tasks.curseforge)


### PR DESCRIPTION
Switches the mixin mod to UniMixins and adds dependency substitution rules to replace all instances of the previous mixin mods (gtnhmixins, mixingasm, spongemixins, spongepoweredmixins) with unimixins - this works across transitive dependencies too.

Tested locally with Hodgepodge & AE2.