### PR TITLE
allow VSC to see minecraft classes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -455,6 +455,12 @@ sourceSets {
             runtimeClasspath += sourceSets.patchedMc.output + sourceSets.mcLauncher.output
         }
     }
+    // This ensures that VSCode knows where the minecraft classes are
+    main {
+        java {
+            compileClasspath += sourceSets.patchedMc.output + sourceSets.mcLauncher.output
+        }
+    }
 }
 
 if (file('addon.gradle').exists()) {


### PR DESCRIPTION
In short before doing this VSCode couldn't see the patched MC folder to see the classes of minecraft and unless one has a  java decompiler extension installed they couldn't see the source code of the classes. Only showing the method names and class names. This fixes it, but i am unsure whether its a good way to fix or not.