### PR TITLE
Update spotless settings version in settings.gradle

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -23,6 +23,6 @@ plugins {
 
 blowdryerSetup {
     repoSubfolder 'gtnhShared'
-    github('GTNewHorizons/ExampleMod1.7.10', 'tag', '0.2.0')
+    github('GTNewHorizons/ExampleMod1.7.10', 'tag', '0.2.1')
     //devLocal '.' // Use this when testing config updates locally
 }


### PR DESCRIPTION
This will need another run of the batch buildsystem updater (adjusted to edit settings.gradle) to apply to old projects, or implementing adjustments to the builtin updater.