### PR TITLE
Add a newline at the end of the warning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,7 @@ plugins {
     id 'com.gtnewhorizons.retrofuturagradle' version '1.3.7'
 }
 
-print("You might want to check out './gradlew :faq' if your build fails.")
+print("You might want to check out './gradlew :faq' if your build fails.\n")
 
 boolean settingsupdated = verifySettingsGradle()
 settingsupdated = verifyGitAttributes() || settingsupdated


### PR DESCRIPTION
Otherwise, a Deprecation warning is written on the same line.