### PR TITLE
Bump hodgepodge version to 2.2.13

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -730,7 +730,7 @@ dependencies {
         java17Dependencies("com.github.GTNewHorizons:lwjgl3ify:${lwjgl3ifyVersion}")
     }
     if (modId != 'hodgepodge') {
-        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.2.8')
+        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.2.12')
     }
 
     java17PatchDependencies('net.minecraft:launchwrapper:1.15') {transitive = false}

--- a/build.gradle
+++ b/build.gradle
@@ -730,7 +730,7 @@ dependencies {
         java17Dependencies("com.github.GTNewHorizons:lwjgl3ify:${lwjgl3ifyVersion}")
     }
     if (modId != 'hodgepodge') {
-        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.2.12')
+        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.2.13')
     }
 
     java17PatchDependencies('net.minecraft:launchwrapper:1.15') {transitive = false}


### PR DESCRIPTION
Hodgepodge 2.2.8 pulls in an old version of gtnh lib, so some mods (like AE2) fail to run in dev w/ java17 because they depend on a newer version (duplicate dependencies).