### PR TITLE
Add Modrinth maven, use exclusiveContent for cursemaven too

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -575,11 +575,26 @@ repositories {
         }
     }
     if (includeWellKnownRepositories.toBoolean()) {
-        maven {
-            name "CurseMaven"
-            url "https://cursemaven.com"
-            content {
+        exclusiveContent {
+            forRepository {
+                maven {
+                    name "CurseMaven"
+                    url "https://cursemaven.com"
+                }
+            }
+            filter {
                 includeGroup "curse.maven"
+            }
+        }
+        exclusiveContent {
+            forRepository {
+                maven {
+                    name = "Modrinth"
+                    url = "https://api.modrinth.com/maven"
+                }
+            }
+            filter {
+                includeGroup "maven.modrinth"
             }
         }
         maven {


### PR DESCRIPTION
Add the [Modrinth maven](https://docs.modrinth.com/docs/tutorials/maven/#resolving-dependencies) to the list of default "well-known" repositories. Also wraps both modrinth and curse mavens into [exclusiveContent](https://docs.gradle.org/current/userguide/declaring_repositories.html#declaring_content_exclusively_found_in_one_repository) blocks for faster dependency resolution