### PR TITLE
Update to LegacyLauncher 1.17.1, fix deprecations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,7 @@ plugins {
     id 'eclipse'
     id 'scala'
     id 'maven-publish'
+    id 'base'
     id 'org.jetbrains.kotlin.jvm' version '1.8.0' apply false
     id 'org.jetbrains.kotlin.kapt' version '1.8.0' apply false
     id 'com.google.devtools.ksp' version '1.8.0-1.0.9' apply false
@@ -401,9 +402,13 @@ if (identifiedVersion == versionOverride) {
 
 group = "com.github.GTNewHorizons"
 if (project.hasProperty("customArchiveBaseName") && customArchiveBaseName) {
-    archivesBaseName = customArchiveBaseName
+    base {
+        archivesName = customArchiveBaseName
+    }
 } else {
-    archivesBaseName = modId
+    base {
+        archivesName = modId
+    }
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,6 @@ plugins {
     id 'eclipse'
     id 'scala'
     id 'maven-publish'
-    id 'base'
     id 'org.jetbrains.kotlin.jvm' version '1.8.0' apply false
     id 'org.jetbrains.kotlin.kapt' version '1.8.0' apply false
     id 'com.google.devtools.ksp' version '1.8.0-1.0.9' apply false

--- a/build.gradle
+++ b/build.gradle
@@ -778,7 +778,7 @@ dependencies {
         java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.2.19')
     }
 
-    java17PatchDependencies('net.minecraft:launchwrapper:1.15') {transitive = false}
+    java17PatchDependencies('net.minecraft:launchwrapper:1.17.1') {transitive = false}
     java17PatchDependencies("org.ow2.asm:asm:${asmVersion}")
     java17PatchDependencies("org.ow2.asm:asm-commons:${asmVersion}")
     java17PatchDependencies("org.ow2.asm:asm-tree:${asmVersion}")


### PR DESCRIPTION
- Updates to LegacyLauncher 1.17.1 for log4j update and for improved logging
- Fixes deprecation warnings determined by gradle scan:
![image](https://github.com/GTNewHorizons/ExampleMod1.7.10/assets/10861407/51e83c5d-c6d8-471a-8d17-823f4010ad32)

