### PR TITLE
Fix wrong mixin refmap filename

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -631,6 +631,8 @@ def mixinProviderSpecNoClassifer = "${mixinProviderGroup}:${mixinProviderModule}
 def mixinProviderSpec = "${mixinProviderSpecNoClassifer}:dev"
 ext.mixinProviderSpec = mixinProviderSpec
 
+def mixingConfigRefMap = 'mixins.' + modId + '.refmap.json'
+
 dependencies {
     if (usesMixins.toBoolean()) {
         annotationProcessor('org.ow2.asm:asm-debug-all:5.0.3')
@@ -642,7 +644,7 @@ dependencies {
         }
     }
     if (usesMixins.toBoolean()) {
-        implementation(modUtils.enableMixins(mixinProviderSpec))
+        implementation(modUtils.enableMixins(mixinProviderSpec, mixingConfigRefMap))
     } else if (forceEnableMixins.toBoolean()) {
         runtimeOnlyNonPublishable(mixinProviderSpec)
     }
@@ -694,8 +696,6 @@ if (file('dependencies.gradle.kts').exists()) {
     logger.error("Neither dependencies.gradle.kts nor dependencies.gradle was found, make sure you extracted the full ExampleMod template.")
     throw new RuntimeException("Missing dependencies.gradle[.kts]")
 }
-
-def mixingConfigRefMap = 'mixins.' + modId + '.refmap.json'
 
 tasks.register('generateAssets') {
     group = "GTNH Buildscript"


### PR DESCRIPTION
Fixes inconsistent refmap naming in case of mods where modid != archiveBaseName, like Galacticraft