### PR TITLE
Bump RFG version to fix java 8 arm64 macos runs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ plugins {
     id 'com.diffplug.spotless' version '6.13.0' apply false // 6.13.0 is the last jvm8 supporting version
     id 'com.modrinth.minotaur' version '2.+' apply false
     id 'com.matthewprenger.cursegradle' version '1.4.0' apply false
-    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.21'
+    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.24'
 }
 
 print("You might want to check out './gradlew :faq' if your build fails.\n")


### PR DESCRIPTION
Tested on a m2 macbook I have access to now, now both runClient and runClient17 work.