### PR TITLE
Respect disableSpotless property

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1152,10 +1152,9 @@ tasks.named("processIdeaSettings").configure {
 
 tasks.named("ideVirtualMainClasses").configure {
     // Make IntelliJ "Build project" build the mod jars
-    if (disableSpotless) {
-        dependsOn("jar", "reobfJar")
-    } else {
-        dependsOn("jar", "reobfJar", "spotlessCheck")
+    dependsOn("jar", "reobfJar")
+    if (!disableSpotless) {
+        dependsOn("spotlessCheck")
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1152,7 +1152,11 @@ tasks.named("processIdeaSettings").configure {
 
 tasks.named("ideVirtualMainClasses").configure {
     // Make IntelliJ "Build project" build the mod jars
-    dependsOn("jar", "reobfJar", "spotlessCheck")
+    if (disableSpotless) {
+        dependsOn("jar", "reobfJar")
+    } else {
+        dependsOn("jar", "reobfJar", "spotlessCheck")
+    }
 }
 
 // workaround variable hiding in pom processing


### PR DESCRIPTION
Building should not depend on `spotlessCheck` if spotless is disabled, as the task is not present.