### PR TITLE
Use fallback maven if maven.ic2.player.to is unavailable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -601,6 +601,9 @@ repositories {
         maven {
             name = "ic2"
             url = getURL("https://maven.ic2.player.to/", "https://maven2.ic2.player.to/")
+            filter {
+                includeGroup "net.industrial-craft"
+            }
             metadataSources {
                 mavenPom()
                 artifact()

--- a/build.gradle
+++ b/build.gradle
@@ -600,15 +600,7 @@ repositories {
         }
         maven {
             name = "ic2"
-            url = "https://maven.ic2.player.to/"
-            metadataSources {
-                mavenPom()
-                artifact()
-            }
-        }
-        maven {
-            name = "ic2-mirror"
-            url = "https://maven2.ic2.player.to/"
+            url = getURL("https://maven.ic2.player.to/", "https://maven2.ic2.player.to/")
             metadataSources {
                 mavenPom()
                 artifact()
@@ -1574,6 +1566,25 @@ def getSecondaryArtifacts() {
     if (!noPublishedSources) secondaryArtifacts += [sourcesJar]
     if (apiPackage) secondaryArtifacts += [apiJar]
     return secondaryArtifacts
+}
+
+def getURL(String main, String fallback) {
+    return pingURL(main, 10000) ? main : fallback
+}
+
+// credit: https://stackoverflow.com/a/3584332
+def pingURL(String url, int timeout) {
+    url = url.replaceFirst("^https", "http") // Otherwise an exception may be thrown on invalid SSL certificates.
+    try {
+        HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection()
+        connection.setConnectTimeout(timeout)
+        connection.setReadTimeout(timeout)
+        connection.setRequestMethod("HEAD")
+        int responseCode = connection.getResponseCode()
+        return 200 <= responseCode && responseCode <= 399
+    } catch (IOException ignored) {
+        return false
+    }
 }
 
 // For easier scripting of things that require variables defined earlier in the buildscript

--- a/build.gradle
+++ b/build.gradle
@@ -601,7 +601,7 @@ repositories {
         maven {
             name = "ic2"
             url = getURL("https://maven.ic2.player.to/", "https://maven2.ic2.player.to/")
-            filter {
+            content {
                 includeGroup "net.industrial-craft"
             }
             metadataSources {


### PR DESCRIPTION
The fallback maven (`https://maven2.ic2.player.to/`) will be used if either the main maven doesn't respond in 10 seconds or it returns a response code outside the acceptable range of 200 - 399.