### PR TITLE
Add a checkstyle lint banning wildcard imports

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,23 @@ def out = services.get(StyledTextOutputFactory).create('an-output')
 def projectJavaVersion = JavaLanguageVersion.of(8)
 
 boolean disableSpotless = project.hasProperty("disableSpotless") ? project.disableSpotless.toBoolean() : false
+boolean disableCheckstyle = project.hasProperty("disableCheckstyle") ? project.disableCheckstyle.toBoolean() : false
+
+final String CHECKSTYLE_CONFIG = """
+<!DOCTYPE module PUBLIC
+  "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+  "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+<module name="Checker">
+  <module name="TreeWalker">
+    <!-- Use CHECKSTYLE:OFF and CHECKSTYLE:ON comments to suppress checkstyle lints in a block -->
+    <module name="SuppressionCommentFilter"/>
+    <module name="AvoidStarImport">
+      <!-- Allow static wildcard imports for cases like Opcodes and LWJGL classes, these don't get created accidentally by the IDE -->
+      <property name="allowStaticMemberImports" value="true"/>
+    </module>
+  </module>
+</module>
+"""
 
 checkPropertyExists("modName")
 checkPropertyExists("modId")
@@ -138,6 +155,17 @@ project.extensions.add(com.diffplug.blowdryer.Blowdryer, "Blowdryer", com.diffpl
 if (!disableSpotless) {
     apply plugin: 'com.diffplug.spotless'
     apply from: Blowdryer.file('spotless.gradle')
+}
+
+if (!disableCheckstyle) {
+    apply plugin: 'checkstyle'
+    tasks.named("checkstylePatchedMc") { enabled = false }
+    tasks.named("checkstyleMcLauncher") { enabled = false }
+    tasks.named("checkstyleIdeVirtualMain") { enabled = false }
+    tasks.named("checkstyleInjectedTags") { enabled = false }
+    checkstyle {
+        config = resources.text.fromString(CHECKSTYLE_CONFIG)
+    }
 }
 
 String javaSourceDir = "src/main/java/"

--- a/gradle.properties
+++ b/gradle.properties
@@ -140,6 +140,9 @@ curseForgeRelations =
 # That is, if there is no other active fork/upstream, NEVER change this.
 # disableSpotless = true
 
+# Uncomment this to disable checkstyle checks (currently wildcard import check).
+# disableCheckstyle = true
+
 # Override the IDEA build type. Valid value is "" (leave blank, do not override), "idea" (force use native IDEA build), "gradle"
 # (force use delegated build).
 # This is meant to be set in $HOME/.gradle/gradle.properties.


### PR DESCRIPTION
Shows an error for every non-static wildcard import in java files in the mod on `build`/`check` gradle tasks:
```
> Task :checkstyleMain FAILED
[ant:checkstyle] [ERROR] /home/raven/MC/modding/1710/ExampleMod1.7.10/src/main/java/com/myname/mymodid/CommonProxy.java:3:33: Using the '.*' form of import should be avoided - cpw.mods.fml.common.event.*. [AvoidStarImport]
[ant:checkstyle] [ERROR] /home/raven/MC/modding/1710/ExampleMod1.7.10/src/main/java/com/myname/mymodid/Config.java:3:15: Using the '.*' form of import should be avoided - java.io.*. [AvoidStarImport]
[ant:checkstyle] [ERROR] /home/raven/MC/modding/1710/ExampleMod1.7.10/src/main/java/com/myname/mymodid/MyMod.java:3:32: Using the '.*' form of import should be avoided - org.apache.logging.log4j.*. [AvoidStarImport]
[ant:checkstyle] [ERROR] /home/raven/MC/modding/1710/ExampleMod1.7.10/src/main/java/com/myname/mymodid/MyMod.java:5:27: Using the '.*' form of import should be avoided - cpw.mods.fml.common.*. [AvoidStarImport]
[ant:checkstyle] [ERROR] /home/raven/MC/modding/1710/ExampleMod1.7.10/src/main/java/com/myname/mymodid/MyMod.java:6:33: Using the '.*' form of import should be avoided - cpw.mods.fml.common.event.*. [AvoidStarImport]
```

Can be suppressed by doing:
```java
// CHECKSTYLE:OFF
import my.mod.magic.*;
// CHECKSTYLE:ON
```
or globally in gradle.properties.