### PR TITLE
Use normal jar for runClient/runServer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -959,21 +959,12 @@ if (usesShadowedDependencies.toBoolean()) {
     configurations.apiElements.outgoing.artifacts.clear()
     configurations.runtimeElements.outgoing.artifact(tasks.named("shadowJar", ShadowJar))
     configurations.apiElements.outgoing.artifact(tasks.named("shadowJar", ShadowJar))
-    tasks.named("jar", Jar) {
-        enabled = false
-        finalizedBy(tasks.shadowJar)
-    }
     tasks.named("reobfJar", ReobfuscatedJar) {
         inputJar.set(tasks.named("shadowJar", ShadowJar).flatMap({it.archiveFile}))
     }
     AdhocComponentWithVariants javaComponent = (AdhocComponentWithVariants) project.components.findByName("java")
     javaComponent.withVariantsFromConfiguration(configurations.shadowRuntimeElements) {
         skip()
-    }
-    for (runTask in ["runClient", "runServer", "runClient17", "runServer17"]) {
-        tasks.named(runTask).configure {
-            dependsOn("shadowJar")
-        }
     }
 }
 ext.publishableDevJar = usesShadowedDependencies.toBoolean() ? tasks.shadowJar : tasks.jar

--- a/build.gradle
+++ b/build.gradle
@@ -959,6 +959,9 @@ if (usesShadowedDependencies.toBoolean()) {
     configurations.apiElements.outgoing.artifacts.clear()
     configurations.runtimeElements.outgoing.artifact(tasks.named("shadowJar", ShadowJar))
     configurations.apiElements.outgoing.artifact(tasks.named("shadowJar", ShadowJar))
+    tasks.named("jar", Jar) {
+        archiveClassifier.set('dev-preshadow')
+    }
     tasks.named("reobfJar", ReobfuscatedJar) {
         inputJar.set(tasks.named("shadowJar", ShadowJar).flatMap({it.archiveFile}))
     }


### PR DESCRIPTION
Configuring `runClient` to depend on `shadowJar` means that shadowing must be run every time a change is made while developing a mod. For mods with a lot of shadowed dependencies (e.g. Angelica), this is painfully slow. 

It shouldn't be necessary to do this as the dependencies are accessible in dev already. Shadowing is only needed at reobf time, and still works there after the change in this PR.