### PR TITLE
Deprecate `gradleTokenModId`, `gradleTokenModName` and `gradleTokenGroupName`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -430,16 +430,16 @@ minecraft {
         }
     }
     if (gradleTokenModId) {
-        injectedTags.put gradleTokenModId, modId
+        out.style(Style.Failure).text('gradleTokenModId is deprecated! The field will no longer be generated.').println()
     }
     if (gradleTokenModName) {
-        injectedTags.put gradleTokenModName, modName
+        out.style(Style.Failure).text('gradleTokenModName is deprecated! The field will no longer be generated.').println()
     }
     if (gradleTokenVersion) {
         injectedTags.put gradleTokenVersion, modVersion
     }
     if (gradleTokenGroupName) {
-        injectedTags.put gradleTokenGroupName, modGroup
+        out.style(Style.Failure).text('gradleTokenGroupName is deprecated! The field will no longer be generated.').println()
     }
     if (enableGenericInjection.toBoolean()) {
         injectMissingGenerics.set(true)

--- a/build.gradle
+++ b/build.gradle
@@ -439,7 +439,7 @@ minecraft {
     }
     if (gradleTokenModName) {
         if (replaceGradleTokenInFile) {
-            injectedTags.put gradleTokenModId, modName
+            injectedTags.put gradleTokenModName, modName
         } else {
             out.style(Style.Failure).text('gradleTokenModName is deprecated! The field will no longer be generated.').println()
         }
@@ -449,7 +449,7 @@ minecraft {
     }
     if (gradleTokenGroupName) {
         if (replaceGradleTokenInFile) {
-            injectedTags.put gradleTokenModId, modGroup
+            injectedTags.put gradleTokenGroupName, modGroup
         } else {
             out.style(Style.Failure).text('gradleTokenGroupName is deprecated! The field will no longer be generated.').println()
         }

--- a/build.gradle
+++ b/build.gradle
@@ -428,18 +428,31 @@ minecraft {
         for (f in replaceGradleTokenInFile.split(',')) {
             tagReplacementFiles.add f
         }
+		out.style(Style.Info).text('replaceGradleTokenInFile is deprecated! Consider using generateGradleTokenClass.').println()
     }
     if (gradleTokenModId) {
-        out.style(Style.Failure).text('gradleTokenModId is deprecated! The field will no longer be generated.').println()
+        if (replaceGradleTokenInFile) {
+            injectedTags.put gradleTokenModId, modId
+        } else {
+            out.style(Style.Failure).text('gradleTokenModId is deprecated! The field will no longer be generated.').println()
+        }
     }
     if (gradleTokenModName) {
-        out.style(Style.Failure).text('gradleTokenModName is deprecated! The field will no longer be generated.').println()
+        if (replaceGradleTokenInFile) {
+            injectedTags.put gradleTokenModId, modName
+        } else {
+            out.style(Style.Failure).text('gradleTokenModName is deprecated! The field will no longer be generated.').println()
+        }
     }
     if (gradleTokenVersion) {
         injectedTags.put gradleTokenVersion, modVersion
     }
     if (gradleTokenGroupName) {
-        out.style(Style.Failure).text('gradleTokenGroupName is deprecated! The field will no longer be generated.').println()
+        if (replaceGradleTokenInFile) {
+            injectedTags.put gradleTokenModId, modGroup
+        } else {
+            out.style(Style.Failure).text('gradleTokenGroupName is deprecated! The field will no longer be generated.').println()
+        }
     }
     if (enableGenericInjection.toBoolean()) {
         injectMissingGenerics.set(true)

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,12 +36,11 @@ enableModernJavaSyntax = true
 # Turns most publicly visible List, Map, etc. into proper List<Type>, Map<K, V> types
 enableGenericInjection = false
 
-# Generate a class with String fields for the mod id, name, version and group name named with the fields below
+# Generate a class with a String field for the mod version named as defined below.
+# If generateGradleTokenClass is empty or not missing, no such class will be generated.
+# If gradleTokenVersion is empty or missing, the field will not be present in the class.
 generateGradleTokenClass = com.myname.mymodid.Tags
-gradleTokenModId = MODID
-gradleTokenModName = MODNAME
 gradleTokenVersion = VERSION
-gradleTokenGroupName = GROUPNAME
 # [DEPRECATED]
 # Multiple source files can be defined here by providing a comma-seperated list: Class1.java,Class2.java,Class3.java
 # public static final String VERSION = "GRADLETOKEN_VERSION";

--- a/src/main/java/com/myname/mymodid/CommonProxy.java
+++ b/src/main/java/com/myname/mymodid/CommonProxy.java
@@ -13,7 +13,7 @@ public class CommonProxy {
         Config.synchronizeConfiguration(event.getSuggestedConfigurationFile());
 
         MyMod.LOG.info(Config.greeting);
-        MyMod.LOG.info("I am " + Tags.MODNAME + " at version " + Tags.VERSION);
+        MyMod.LOG.info("I am MyMod at version " + Tags.VERSION);
     }
 
     // load "Do your mod setup. Build whatever data structures you care about. Register recipes." (Remove if not needed)

--- a/src/main/java/com/myname/mymodid/MyMod.java
+++ b/src/main/java/com/myname/mymodid/MyMod.java
@@ -10,9 +10,10 @@ import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.common.event.FMLServerStartingEvent;
 
-@Mod(modid = Tags.MODID, version = Tags.VERSION, name = Tags.MODNAME, acceptedMinecraftVersions = "[1.7.10]")
+@Mod(modid = MyMod.MODID, version = Tags.VERSION, name = "MyMod", acceptedMinecraftVersions = "[1.7.10]")
 public class MyMod {
 
+    public static final String MODID = "mymodid";
     public static final Logger LOG = LogManager.getLogger(Tags.MODID);
 
     @SidedProxy(clientSide = "com.myname.mymodid.ClientProxy", serverSide = "com.myname.mymodid.CommonProxy")

--- a/src/main/java/com/myname/mymodid/MyMod.java
+++ b/src/main/java/com/myname/mymodid/MyMod.java
@@ -14,7 +14,7 @@ import cpw.mods.fml.common.event.FMLServerStartingEvent;
 public class MyMod {
 
     public static final String MODID = "mymodid";
-    public static final Logger LOG = LogManager.getLogger(Tags.MODID);
+    public static final Logger LOG = LogManager.getLogger(MODID);
 
     @SidedProxy(clientSide = "com.myname.mymodid.ClientProxy", serverSide = "com.myname.mymodid.CommonProxy")
     public static CommonProxy proxy;


### PR DESCRIPTION
Having these properties exposed implies that they can be changed at any time (like the version). However, this is not the case (especially for the modID).