### PR TITLE
Allow restricting the Version format

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,6 +122,7 @@ propertyDefaultIfUnset("modrinthProjectId", "")
 propertyDefaultIfUnset("modrinthRelations", "")
 propertyDefaultIfUnset("curseForgeProjectId", "")
 propertyDefaultIfUnset("curseForgeRelations", "")
+propertyDefaultIfUnset("versionPattern", "")
 propertyDefaultIfUnset("minimizeShadowedDependencies", true)
 propertyDefaultIfUnset("relocateShadowedDependencies", true)
 // Deprecated properties (kept for backwards compat)
@@ -370,6 +371,7 @@ catch (Exception ignored) {
 // Pulls version first from the VERSION env and then git tag
 String identifiedVersion
 String versionOverride = System.getenv("VERSION") ?: null
+boolean checkVersion = false
 try {
     // Produce a version based on the tag, or for branches something like 0.2.2-configurable-maven-and-extras.38+43090270b6-dirty
     if (versionOverride == null) {
@@ -388,6 +390,8 @@ try {
             }
         } else if (isDirty) {
             identifiedVersion += "-${branchName}+${gitDetails.gitHash}-dirty"
+        } else {
+            checkVersion = true
         }
     } else {
         identifiedVersion = versionOverride
@@ -409,6 +413,8 @@ ext {
 
 if (identifiedVersion == versionOverride) {
     out.style(Style.Failure).text('Override version to ').style(Style.Identifier).text(modVersion).style(Style.Failure).println('!\7')
+} else if (checkVersion && versionPattern && !(identifiedVersion ==~ versionPattern)) {
+    throw new GradleException("Invalid version: '$identifiedVersion' does not match version pattern '$versionPattern'")
 }
 
 group = "com.github.GTNewHorizons"
@@ -428,7 +434,7 @@ minecraft {
         for (f in replaceGradleTokenInFile.split(',')) {
             tagReplacementFiles.add f
         }
-		out.style(Style.Info).text('replaceGradleTokenInFile is deprecated! Consider using generateGradleTokenClass.').println()
+        out.style(Style.Info).text('replaceGradleTokenInFile is deprecated! Consider using generateGradleTokenClass.').println()
     }
     if (gradleTokenModId) {
         if (replaceGradleTokenInFile) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -131,6 +131,12 @@ curseForgeRelations =
 # projects. New projects should not use this parameter.
 # customArchiveBaseName =
 
+# Optional parameter to have the build automatically fail if an illegal version is used.
+# This can be usefull, if you e.g. only want to allow versions in the form of '1.1.xxx'.
+# The check is ONLY performed if the version is a git tag.
+# Note: the specified string must be escaped, so e.g. 1\\.1\\.\\d+ instead of 1\.1\.\d+
+# versionPattern =
+
 # Optional parameter to prevent the source code from being published
 # noPublishedSources =
 


### PR DESCRIPTION
This PR introduces an (optional) property to check the tagged version via regex. This can be usefull for projects like OpenModeLib, where the version should always start with `1.10.`. If an illegal version is detected (e.g. `1.11.0-GTNH`), the build fails with an appropriate error message. Note: this check is only performed for tagged versions. In dev or when using a version override, it is not performed.