### PR TITLE
Set `useDependencyInformation` to false by default

### DIFF
--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -16,6 +16,6 @@
 		"requiredMods": [],
 		"dependencies": [],
 		"dependants": [],
-		"useDependencyInformation": true
+		"useDependencyInformation": false
 	}]
 }


### PR DESCRIPTION
Due to https://github.com/GTNewHorizons/MouseTweaks/pull/5#discussion_r1451557700 and https://discord.com/channels/181078474394566657/603348502637969419/1197899324613459989.

While declaring dependencies in `mcmod.info` is the more modern way, usually the `@Mod` annotation is still used in 1.7.10. So modders using this buildscript might not notice that `"useDependencyInformation" = true` silently breaks there assumptions because FML only uses the dependency properties from the `@Mod` annotation if `"useDependencyInformation" = false` *or* `@Mod(useMetadata = false)` (Note: while `useMetadata` is false by default, it only works as such when actually declared as false in the `@Mod` annotation). *[source](https://github.com/MinecraftForge/FML/blob/1.7.10/src/main/java/cpw/mods/fml/common/FMLModContainer.java#L155-L177)*