### PR TITLE
redirect to SinTh0r4s' repo for the access transformers example

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ We also have described guidelines for existing mod [migration](docs/migration.md
 
 You may activate Forge's Access Transformers by defining a configuration file in `gradle.properties`.
 
-Check out the [`example-access-transformers`](https://github.com/GTNewHorizons/ExampleMod1.7.10/tree/example-access-transformers) branch for a working example!
+Check out the [`example-access-transformers`](https://github.com/SinTh0r4s/ExampleMod1.7.10/tree/example-access-transformers) branch for a working example!
 
 __Warning:__ Access Transformers are bugged and will deny you any sources for the decompiled minecraft! Your development environment will still work, but you might face some inconveniences. For example, IntelliJ will not permit searches in dependencies without attached sources.
 


### PR DESCRIPTION
you don't have a branch for `example-access-transformers`, which your README redirects to (and 404's). This makes that hyperlink point to the SinTh0r4s repository, but adding that branch here would be good too (probably better, but I lazy)

Closes: #275