### PR TITLE
Update buildscript and switch main scripts to Kotlin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,0 @@
-
-plugins {
-    id 'com.gtnewhorizons.gtnhconvention'
-}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,4 @@
+
+plugins {
+    id("com.gtnewhorizons.gtnhconvention")
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew
+++ b/gradlew
@@ -86,8 +86,7 @@ done
 # shellcheck disable=SC2034
 APP_BASE_NAME=${0##*/}
 # Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
-APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s
-' "$PWD" ) || exit
+APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s\n' "$PWD" ) || exit
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD=maximum

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,8 +3,8 @@ pluginManagement {
     repositories {
         maven {
             // RetroFuturaGradle
-            name "GTNH Maven"
-            url "https://nexus.gtnewhorizons.com/repository/public/"
+            name = "GTNH Maven"
+            url = uri("https://nexus.gtnewhorizons.com/repository/public/")
             mavenContent {
                 includeGroup("com.gtnewhorizons")
                 includeGroupByRegex("com\\.gtnewhorizons\\..+")
@@ -17,5 +17,5 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.30'
+    id("com.gtnewhorizons.gtnhsettingsconvention") version("1.0.33")
 }


### PR DESCRIPTION
- Update GTNHGradle
- Update Gradle
- Switch `build` and `settings` scripts from Groovy to Kotlin - they provide better IntelliJ integration and are where Gradle focuses its development efforts now.

The dependencies/repositories scripts remain as Groovy because switching them to Kotlin causes a lot of Gradle types to be inaccessible without weakly typed string-based accessors, this is due to gradle's classpath restrictions of what addon scripts can see.