### PR TITLE
Update spotless.eclipseformat.xml

### DIFF
--- a/gtnhShared/spotless.eclipseformat.xml
+++ b/gtnhShared/spotless.eclipseformat.xml
@@ -224,7 +224,7 @@
         <setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="49"/>
         <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="1"/>
         <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_end_of_method_body" value="0"/>
-        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_if_while_statement" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_if_while_statement" value="separate_lines_if_wrapped"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_brace_in_block" value="insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_return" value="insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_arrow_in_switch_case" value="insert"/>


### PR DESCRIPTION
Works around an annoying bug in Eclipse Formatter with chained IF/ELSE when (&& and ||) are used

Before:
![image](https://github.com/user-attachments/assets/e7b1e872-b805-462a-8138-70a1d6cfa748)


After:
![image](https://github.com/user-attachments/assets/4e130185-ab14-4427-b34c-d1ba2263453b)
