### PR TITLE
Imply that the "containsMixinsAndOrCoreModOnly" property will prevent late mixins from being loaded

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -95,8 +95,8 @@ mixinsPackage =
 # Example value: (coreModClass = asm.FMLPlugin) + (modGroup = com.myname.mymodid) -> com.myname.mymodid.asm.FMLPlugin
 coreModClass =
 
-# If your project is only a consolidation of mixins or a core mod and does NOT contain a 'normal' mod ( = some class
-# that is annotated with @Mod) you want this to be true. When in doubt: leave it on false!
+# If your project is only a consolidation of early mixins or a core mod and does NOT contain a 'normal' mod ( = some
+# class that is annotated with @Mod) you want this to be true. When in doubt: leave it on false!
 containsMixinsAndOrCoreModOnly = false
 
 # Enables Mixins even if this mod doesn't use them, useful if one of the dependencies uses mixins.


### PR DESCRIPTION
Updates the comment above `containsMixinsAndOrCoreModOnly` in gradle.properties to specify "early mixins" instead of just "mixins". The way the comment is worded had me under the impression that this included "late" mixins, and it created lots of headache...

I feel like I won't be the only one this trips up, which is why I've decided to turn this into a PR. If there's an even better way to word this, feel free to edit.