### PR TITLE
Consistency fix in gradle.properties (GTNH mixins -> Unimixins)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -142,7 +142,7 @@ modrinthProjectId =
 #       type can be one of [project, version],
 #       and the name is the Modrinth project or version slug/id of the other mod.
 # Example: required-project:fplib;optional-project:gasstation;incompatible-project:gregtech
-# Note: GTNH Mixins is automatically set as a required dependency if usesMixins = true
+# Note: UniMixins is automatically set as a required dependency if usesMixins = true
 modrinthRelations =
 
 # Publishing to CurseForge requires you to set the CURSEFORGE_TOKEN environment variable to one of your CurseForge API tokens.


### PR DESCRIPTION
# Low priority


Fixes the note for modrinthRelations to match the note for curseforgeRelations (GTNH mixins -> Unimixins)
Matches a change made in https://github.com/GTNewHorizons/ExampleMod1.7.10/pull/171
Now matches https://github.com/GTNewHorizons/ExampleMod1.7.10/blob/624a358862294ebbd8a2d9c4920a1c770d6d42a2/gradle.properties#L159