### PR TITLE
Remove NEI from deps

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -34,5 +34,5 @@
  * For more details, see https://docs.gradle.org/8.0.1/userguide/java_library_plugin.html#sec:java_library_configurations_graph
  */
 dependencies {
-    runtimeOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.7.4-GTNH:dev")
+    //runtimeOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.7.69-GTNH:dev")
 }


### PR DESCRIPTION
The example mod should be as minimal as possible. I think the NEI dependency should be removed to not bring in any bugs / unwanted behavior such as transitively pulling outdated libraries.