### PR TITLE
Make kotlin spotless config work

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,5 +18,5 @@ end_of_line = crlf
 [*.{dtd,json,info,mcmeta,md,sh,svg,xml,xsd,xsl,yaml,yml}]
 indent_size = 2
 
-[*.lang]
+[*.{lang,md}]
 trim_trailing_whitespace = false

--- a/gtnhShared/spotless.gradle
+++ b/gtnhShared/spotless.gradle
@@ -20,21 +20,21 @@ spotless {
         toggleOffOn()
         importOrderFile(Blowdryer.file('spotless.importorder'))
         removeUnusedImports()
-        eclipse('4.19.0').configFile(Blowdryer.file('spotless.eclipseformat.xml'))
+        eclipse('4.19').configFile(Blowdryer.file('spotless.eclipseformat.xml'))
     }
     kotlin {
-        target 'src/*/kotlin/**/*.kt'
+        target 'src/*/kotlin/**/*.kt', 'src/*/java/**/*.kt'
 
         toggleOffOn()
-        ktfmt('0.39')
-
         trimTrailingWhitespace()
-        indentWithSpaces(4)
         endWithNewline()
+        ktlint('1.7.1').editorConfigOverride([
+            'ktlint_code_style': 'intellij_idea'
+        ])
     }
     scala {
         target 'src/*/scala/**/*.scala'
 
-        scalafmt('3.7.1')
+        scalafmt('3.7.15')
     }
 }


### PR DESCRIPTION
While @Kynake was working on a port of BetterFoliage to our buildscripts they noticed that our kotlin formatting settings weren't working. It turned out that `indentWithSpaces` didn't seem to take effect. Instead, we move that setting into the formatter directly. Switch to `ktlint` for java 8 compatibility. This should be fine as we currently have 2.5 or so mods with kotlin in them.

This also updates the targeted files for kotlin as for example BetterP2P has them in `src/main/java`.