### PR TITLE
feat(spotless): prettier json

### DIFF
--- a/gtnhShared/spotless.gradle
+++ b/gtnhShared/spotless.gradle
@@ -37,4 +37,23 @@ spotless {
 
         scalafmt('3.7.15')
     }
+    json {
+        ratchetFrom 'origin/master' // only format files which have changed since origin/master
+
+        target(
+            'src/**/mcmod.info',
+            'src/**/*.json',
+            'src/**/*.mcmeta'
+        )
+
+        prettier().config([
+            parser: 'json',
+            printWidth: 100,
+            tabWidth: 2,
+            objectWrap: "collapse",
+            useTabs: false,
+            endOfLine: 'lf'
+        ])
+        endWithNewline()
+    }
 }


### PR DESCRIPTION
Normalizes json files matching:
- `src/**/mcmod.info`
- `src/**/*.json`
- `src/**/*.mcmeta`

Processes only changed files from `origin/master`.

Normalizations:
- Indent with 2 spaces
- Preserves collapsed objects/arrays on same line when it does not exceed 100 chars
- Uses unix newline LF
- Ends file with a newline character

Sample diffs:

```diff
--- a/src/main/resources/assets/gtnhintergalactic/textures/items/drones/MiningDroneUMV.png.mcmeta
+++ b/src/main/resources/assets/gtnhintergalactic/textures/items/drones/MiningDroneUMV.png.mcmeta
@@ -1 +1 @@
-{"animation": {"frametime": 3}}
+{ "animation": { "frametime": 3 } }
```

```diff
--- a/src/main/resources/assets/gregtech/textures/blocks/iconsets/BLOCK_SIXPHASEDCOPPER.png.mcmeta
+++ b/src/main/resources/assets/gregtech/textures/blocks/iconsets/BLOCK_SIXPHASEDCOPPER.png.mcmeta
@@ -1 +1 @@
-{ "animation": { "frametime": 1, "frames": [ 0, 1, 0, 1, 0, { "index": 2, "time": 75 } ] } }
\ No newline at end of file
+{ "animation": { "frametime": 1, "frames": [0, 1, 0, 1, 0, { "index": 2, "time": 75 }] } }
```

```diff
--- a/src/main/resources/assets/gtnhintergalactic/textures/blocks/spaceElevator/cable/CableLightBlinking24.pn>
+++ b/src/main/resources/assets/gtnhintergalactic/textures/blocks/spaceElevator/cable/CableLightBlinking24.pn>
@@ -1,5 +1,4 @@
-
-        {
-        "animation": {
-        "frames": [
-        {
+{
+  "animation": {
+    "frames": [
+      {
@@ -8,2 +7,2 @@
-        },
-        {
+      },
+      {
@@ -12,2 +11,2 @@
-        },
-        {
+      },
+      {
@@ -16,5 +15,4 @@
-        }
-        ]
-        }
-        }
-
\ No newline at end of file
+      }
+    ]
+  }
+}
```